### PR TITLE
Edited the num of concurent streams amd gpus

### DIFF
--- a/interfaces/hip/Control.cpp
+++ b/interfaces/hip/Control.cpp
@@ -47,7 +47,11 @@ void ConcreteAPI::initialize() {
 void ConcreteAPI::createCircularStreamAndEvents() {
   isFlagSet<StatusID::InterfaceInitialized>(status);
 
+#ifdef CUDA_UNDERHOOD
   constexpr size_t concurrencyLevel{32};
+#else
+  constexpr size_t concurrencyLevel{8};
+#endif
   circularStreamBuffer.resize(concurrencyLevel);
   for (auto &stream : circularStreamBuffer) {
     hipStreamCreateWithFlags(&stream, hipStreamNonBlocking); CHECK_ERR;


### PR DESCRIPTION
Desceased the number of concurrent streams for AMD GPUs. Synchronizing 32 streams entails high overheads. 8 streams resulted in better performance in SeisSol-proxy