### PR TITLE
Update Algorithms, add oneAPI Compute Graphing

### DIFF
--- a/AbstractAPI.h
+++ b/AbstractAPI.h
@@ -36,6 +36,9 @@ struct AbstractAPI {
   virtual void syncDevice() = 0;
   virtual void checkOffloading() = 0;
 
+  virtual std::string getApiName() = 0;
+  virtual std::string getDeviceName(int deviceId) = 0;
+
   virtual void allocateStackMem() = 0;
   virtual void *allocGlobMem(size_t size) = 0;
   virtual void *allocUnifiedMem(size_t size) = 0;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ if (NOT DEFINED DEVICE_ARCH)
             "Supported for example: sm_60, sm_61, sm_70, sm_71, gfx906, gfx908, dg1, bdw, skl, Gen8, Gen9, Gen11, Gen12LP")
 endif()
 
-
 #check REAL_SIZE
 if (NOT DEFINED REAL_SIZE_IN_BYTES)
     message(FATAL_ERROR "REAL_SIZE_IN_BYTES variable has not been provided into the submodule")
@@ -70,6 +69,10 @@ if (ENABLE_PROFILING_MARKERS)
 endif()
 
 target_compile_definitions(device PRIVATE DEVICE_${BACKEND_UPPER_CASE}_LANG REAL_SIZE=${REAL_SIZE_IN_BYTES})
+
+if (LOG_LEVEL_MASTER)
+  target_compile_definitions(device PRIVATE LOG_LEVEL=${LOG_LEVEL_MASTER})
+endif()
 
 target_include_directories(device PRIVATE .
                                           interfaces/${BACKEND_FOLDER}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ elseif((${DEVICE_BACKEND} STREQUAL "oneapi") OR (${DEVICE_BACKEND} STREQUAL "hip
 endif()
 
 # common options
-target_compile_features(device PRIVATE cxx_std_14)
+target_compile_features(device PRIVATE cxx_std_17)
 
 if (USE_GRAPH_CAPTURING)
   target_compile_definitions(device PRIVATE DEVICE_USE_GRAPH_CAPTURING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(device_submodule)
 
 #set(CMAKE_CXX_CLANG_TIDY clang-tidy)
-option(USE_GRAPH_CAPTURING "Enable graph capturing if it is supported" OFF)
+option(USE_GRAPH_CAPTURING "Enable graph capturing (if it is supported)" ON)
 
 # check INTERFACE
 if (NOT DEFINED DEVICE_BACKEND)
@@ -42,11 +42,12 @@ endif()
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
-option(ENABLE_PROFILING_MARKERS "enable profiling markers if available" OFF)
+option(ENABLE_PROFILING_MARKERS "Enable profiling markers (if available)" OFF)
 
 string(TOLOWER ${DEVICE_BACKEND} BACKEND_FOLDER)
 string(TOUPPER ${DEVICE_BACKEND} BACKEND_UPPER_CASE)
 
+# define device library
 if (${DEVICE_BACKEND} STREQUAL "cuda")
     set(BACKEND_FOLDER "cuda")
     include(cuda.cmake)
@@ -58,6 +59,16 @@ elseif((${DEVICE_BACKEND} STREQUAL "oneapi") OR (${DEVICE_BACKEND} STREQUAL "hip
     include(sycl.cmake)
 endif()
 
+# common options
+target_compile_features(device PRIVATE cxx_std_14)
+
+if (USE_GRAPH_CAPTURING)
+  target_compile_definitions(device PRIVATE DEVICE_USE_GRAPH_CAPTURING)
+endif()
+if (ENABLE_PROFILING_MARKERS)
+  target_compile_definitions(device PRIVATE PROFILING_ENABLED)
+endif()
+
 target_compile_definitions(device PRIVATE DEVICE_${BACKEND_UPPER_CASE}_LANG REAL_SIZE=${REAL_SIZE_IN_BYTES})
 
 target_include_directories(device PRIVATE .
@@ -65,7 +76,3 @@ target_include_directories(device PRIVATE .
                                           interfaces/common
                                           algorithms/${BACKEND_FOLDER}
                                           submodules)
-
-target_compile_options(device PRIVATE -fPIC)
-
-

--- a/algorithms/cuda/ArrayManip.cu
+++ b/algorithms/cuda/ArrayManip.cu
@@ -15,7 +15,7 @@ template <typename T> void Algorithms::scaleArray(T *devArray,
                                                   T scalar,
                                                   const size_t numElements,
                                                   void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   kernel_scaleArray<<<grid, block, 0, stream>>>(devArray, scalar, numElements);
@@ -34,7 +34,7 @@ template <typename T> __global__ void kernel_fillArray(T *array, T scalar, const
 }
 
 template <typename T> void Algorithms::fillArray(T *devArray, const T scalar, const size_t numElements, void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   kernel_fillArray<<<grid, block, 0, stream>>>(devArray, scalar, numElements);
@@ -62,7 +62,7 @@ __global__ void kernel_touchMemory(real *ptr, size_t size, bool clean) {
 }
 
 void Algorithms::touchMemory(real *ptr, size_t size, bool clean, void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, size);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   kernel_touchMemory<<<grid, block, 0, stream>>>(ptr, size, clean);
@@ -89,7 +89,7 @@ void Algorithms::incrementalAdd(
   size_t numElements,
   void* streamPtr) {
 
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   kernel_incrementalAdd<<<grid, block, 0, stream>>>(out, base, increment, numElements);

--- a/algorithms/cuda/ArrayManip.cu
+++ b/algorithms/cuda/ArrayManip.cu
@@ -52,7 +52,7 @@ __global__ void kernel_touchMemory(real *ptr, size_t size, bool clean) {
     if (clean) {
       ptr[id] = 0;
     } else {
-      real value = ptr[id];
+      real& value = ptr[id];
       // Do something dummy here. We just need to check the pointers point to valid memory locations.
       // Avoid compiler optimization. Possibly, implement a dummy code with asm.
       value += 1;

--- a/algorithms/cuda/ArrayManip.cu
+++ b/algorithms/cuda/ArrayManip.cu
@@ -15,7 +15,7 @@ template <typename T> void Algorithms::scaleArray(T *devArray,
                                                   T scalar,
                                                   const size_t numElements,
                                                   void* streamPtr) {
-  dim3 block(64, 1, 1);
+  dim3 block(DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   kernel_scaleArray<<<grid, block, 0, stream>>>(devArray, scalar, numElements);
@@ -34,7 +34,7 @@ template <typename T> __global__ void kernel_fillArray(T *array, T scalar, const
 }
 
 template <typename T> void Algorithms::fillArray(T *devArray, const T scalar, const size_t numElements, void* streamPtr) {
-  dim3 block(64, 1, 1);
+  dim3 block(DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   kernel_fillArray<<<grid, block, 0, stream>>>(devArray, scalar, numElements);
@@ -62,7 +62,7 @@ __global__ void kernel_touchMemory(real *ptr, size_t size, bool clean) {
 }
 
 void Algorithms::touchMemory(real *ptr, size_t size, bool clean, void* streamPtr) {
-  dim3 block(256, 1, 1);
+  dim3 block(DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, size);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   kernel_touchMemory<<<grid, block, 0, stream>>>(ptr, size, clean);
@@ -89,7 +89,7 @@ void Algorithms::incrementalAdd(
   size_t numElements,
   void* streamPtr) {
 
-  dim3 block(256, 1, 1);
+  dim3 block(DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   kernel_incrementalAdd<<<grid, block, 0, stream>>>(out, base, increment, numElements);

--- a/algorithms/cuda/BatchManip.cu
+++ b/algorithms/cuda/BatchManip.cu
@@ -63,7 +63,7 @@ namespace device {
         if (clean) {
           element[index] = 0.0;
         } else {
-          real value = element[index];
+          real& value = element[index];
           // Do something dummy here. We just need to check the pointers point to valid memory locations.
           // Avoid compiler optimization. Possibly, implement a dummy code with asm.
           value += 1.0;

--- a/algorithms/cuda/BatchManip.cu
+++ b/algorithms/cuda/BatchManip.cu
@@ -11,7 +11,7 @@ namespace device {
     real *srcElement = baseSrcPtr[blockIdx.x];
     real *dstElement = baseDstPtr[blockIdx.x];
 #pragma unroll 4
-    for (int index = threadIdx.x; index < elementSize; index += DefaultBlockDim) {
+    for (int index = threadIdx.x; index < elementSize; index += device::internals::DefaultBlockDim) {
       dstElement[index] = srcElement[index];
     }
   }
@@ -21,7 +21,7 @@ namespace device {
                                      unsigned elementSize,
                                      unsigned numElements,
                                      void* streamPtr) {
-    dim3 block(DefaultBlockDim, 1, 1);
+    dim3 block(device::internals::DefaultBlockDim, 1, 1);
     dim3 grid(numElements, 1, 1);
     auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
     kernel_streamBatchedData<<<grid, block, 0, stream>>>(baseSrcPtr, baseDstPtr, elementSize);
@@ -37,7 +37,7 @@ namespace device {
     real *srcElement = baseSrcPtr[blockIdx.x];
     real *dstElement = baseDstPtr[blockIdx.x];
 #pragma unroll 4
-    for (int index = threadIdx.x; index < elementSize; index += DefaultBlockDim) {
+    for (int index = threadIdx.x; index < elementSize; index += device::internals::DefaultBlockDim) {
       dstElement[index] += srcElement[index];
     }
   }
@@ -47,7 +47,7 @@ namespace device {
                                          unsigned elementSize,
                                          unsigned numElements,
                                          void* streamPtr) {
-    dim3 block(DefaultBlockDim, 1, 1);
+    dim3 block(device::internals::DefaultBlockDim, 1, 1);
     dim3 grid(numElements, 1, 1);
     auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
     kernel_accumulateBatchedData<<<grid, block, 0, stream>>>(baseSrcPtr, baseDstPtr, elementSize);
@@ -59,7 +59,7 @@ namespace device {
     real *element = basePtr[blockIdx.x];
     if (element != nullptr) {
 #pragma unroll 4
-      for (int index = threadIdx.x; index < elementSize; index += DefaultBlockDim) {
+      for (int index = threadIdx.x; index < elementSize; index += device::internals::DefaultBlockDim) {
         if (clean) {
           element[index] = 0.0;
         } else {
@@ -78,7 +78,7 @@ namespace device {
                                       unsigned numElements,
                                       bool clean,
                                       void* streamPtr) {
-    dim3 block(DefaultBlockDim, 1, 1);
+    dim3 block(device::internals::DefaultBlockDim, 1, 1);
     dim3 grid(numElements, 1, 1);
     auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
     kernel_touchBatchedMemory<<<grid, block, 0, stream>>>(basePtr, elementSize, clean);
@@ -90,16 +90,15 @@ __global__  void kernel_setToValue(real** out, real value, size_t elementSize, s
   const int elementId = blockIdx.x;
   if (elementId < numElements) {
     real *element = out[elementId];
-    const int tid = threadIdx.x;
 #pragma unroll 4
-    for (int index = threadIdx.x; index < elementSize; index += DefaultBlockDim) {
+    for (int index = threadIdx.x; index < elementSize; index += device::internals::DefaultBlockDim) {
       element[index] = value;
     }
   }
 }
 
 void Algorithms::setToValue(real** out, real value, size_t elementSize, size_t numElements, void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid(numElements, 1, 1);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   kernel_setToValue<<<grid, block, 0, stream>>>(out, value, elementSize, numElements);
@@ -112,7 +111,7 @@ void Algorithms::setToValue(real** out, real value, size_t elementSize, size_t n
     T *srcElement = &src[blockIdx.x * srcOffset];
     T *dstElement = dst[blockIdx.x];
 #pragma unroll 4
-    for (int index = threadIdx.x; index < copySize; index += DefaultBlockDim) {
+    for (int index = threadIdx.x; index < copySize; index += device::internals::DefaultBlockDim) {
       dstElement[index] = srcElement[index];
     }
   }
@@ -124,7 +123,7 @@ void Algorithms::setToValue(real** out, real value, size_t elementSize, size_t n
                                         size_t copySize,
                                         size_t numElements,
                                         void* streamPtr) {
-    dim3 block(DefaultBlockDim, 1, 1);
+    dim3 block(device::internals::DefaultBlockDim, 1, 1);
     dim3 grid(numElements, 1, 1);
     auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
     kernel_copyUniformToScatter<<<grid, block, 0, stream>>>(src, dst, srcOffset, copySize); CHECK_ERR;
@@ -157,7 +156,7 @@ void Algorithms::setToValue(real** out, real value, size_t elementSize, size_t n
     T *srcElement = src[blockIdx.x];
     T *dstElement = &dst[blockIdx.x * dstOffset];
 #pragma unroll 4
-    for (int index = threadIdx.x; index < copySize; index += DefaultBlockDim) {
+    for (int index = threadIdx.x; index < copySize; index += device::internals::DefaultBlockDim) {
       dstElement[index] = srcElement[index];
     }
   }
@@ -169,7 +168,7 @@ void Algorithms::setToValue(real** out, real value, size_t elementSize, size_t n
                                         size_t copySize,
                                         size_t numElements,
                                         void* streamPtr) {
-    dim3 block(DefaultBlockDim, 1, 1);
+    dim3 block(device::internals::DefaultBlockDim, 1, 1);
     dim3 grid(numElements, 1, 1);
     auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
     kernel_copyScatterToUniform<<<grid, block, 0, stream>>>(src, dst, dstOffset, copySize);

--- a/algorithms/hip/ArrayManip.cpp
+++ b/algorithms/hip/ArrayManip.cpp
@@ -15,7 +15,7 @@ template <typename T> void Algorithms::scaleArray(T *devArray,
                                                   T scalar, 
                                                   const size_t numElements,
                                                   void* streamPtr) {
-  dim3 block(64, 1, 1);
+  dim3 block(DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_scaleArray, grid, block, 0, stream, devArray, scalar, numElements);
@@ -36,7 +36,7 @@ template <typename T> void Algorithms::fillArray(T *devArray,
                                                  const T scalar, 
                                                  const size_t numElements,
                                                  void* streamPtr) {
-  dim3 block(64, 1, 1);
+  dim3 block(DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_fillArray, grid, block, 0, stream, devArray, scalar, numElements);
@@ -64,7 +64,7 @@ __global__ void kernel_touchMemory(real *ptr, size_t size, bool clean) {
 }
 
 void Algorithms::touchMemory(real *ptr, size_t size, bool clean, void* streamPtr) {
-  dim3 block(256, 1, 1);
+  dim3 block(DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, size);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_touchMemory, grid, block, 0, stream, ptr, size, clean);
@@ -91,7 +91,7 @@ void Algorithms::incrementalAdd(
   size_t numElements,
   void* streamPtr) {
 
-  dim3 block(256, 1, 1);
+  dim3 block(DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_incrementalAdd,

--- a/algorithms/hip/ArrayManip.cpp
+++ b/algorithms/hip/ArrayManip.cpp
@@ -54,7 +54,7 @@ __global__ void kernel_touchMemory(real *ptr, size_t size, bool clean) {
     if (clean) {
       ptr[id] = 0;
     } else {
-      real value = ptr[id];
+      real& value = ptr[id];
       // Do something dummy here. We just need to check the pointers point to valid memory locations.
       // Avoid compiler optimization. Possibly, implement a dummy code with asm.
       value += 1;

--- a/algorithms/hip/ArrayManip.cpp
+++ b/algorithms/hip/ArrayManip.cpp
@@ -15,7 +15,7 @@ template <typename T> void Algorithms::scaleArray(T *devArray,
                                                   T scalar, 
                                                   const size_t numElements,
                                                   void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_scaleArray, grid, block, 0, stream, devArray, scalar, numElements);
@@ -36,7 +36,7 @@ template <typename T> void Algorithms::fillArray(T *devArray,
                                                  const T scalar, 
                                                  const size_t numElements,
                                                  void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_fillArray, grid, block, 0, stream, devArray, scalar, numElements);
@@ -64,7 +64,7 @@ __global__ void kernel_touchMemory(real *ptr, size_t size, bool clean) {
 }
 
 void Algorithms::touchMemory(real *ptr, size_t size, bool clean, void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, size);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_touchMemory, grid, block, 0, stream, ptr, size, clean);
@@ -91,7 +91,7 @@ void Algorithms::incrementalAdd(
   size_t numElements,
   void* streamPtr) {
 
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid = internals::computeGrid1D(block, numElements);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_incrementalAdd,

--- a/algorithms/hip/BatchManip.cpp
+++ b/algorithms/hip/BatchManip.cpp
@@ -64,7 +64,7 @@ __global__ void kernel_touchBatchedMemory(real **basePtr,
       if (clean) {
         element[index] = 0.0;
       } else {
-        real value = element[index];
+        real& value = element[index];
         // Do something dummy here. We just need to check the pointers point to valid memory locations.
         // Avoid compiler optimization. Possibly, implement a dummy code with asm.
         value += 1.0;

--- a/algorithms/hip/BatchManip.cpp
+++ b/algorithms/hip/BatchManip.cpp
@@ -11,7 +11,7 @@ __global__ void kernel_streamBatchedData(real **baseSrcPtr,
   real *srcElement = baseSrcPtr[hipBlockIdx_x];
   real *dstElement = baseDstPtr[hipBlockIdx_x];
 #pragma unroll 4
-  for (int index = hipThreadIdx_x; index < elementSize; index += DefaultBlockDim) {
+  for (int index = hipThreadIdx_x; index < elementSize; index += device::internals::DefaultBlockDim) {
     dstElement[index] = srcElement[index];
   }
 }
@@ -21,7 +21,7 @@ void Algorithms::streamBatchedData(real **baseSrcPtr,
                                    unsigned elementSize, 
                                    unsigned numElements, 
                                    void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid(numElements, 1, 1);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_streamBatchedData, grid, block, 0, stream, baseSrcPtr, baseDstPtr, elementSize);
@@ -36,7 +36,7 @@ __global__ void kernel_accumulateBatchedData(real **baseSrcPtr,
   real *srcElement = baseSrcPtr[hipBlockIdx_x];
   real *dstElement = baseDstPtr[hipBlockIdx_x];
 #pragma unroll 4
-  for (int index = hipThreadIdx_x; index < elementSize; index += DefaultBlockDim) {
+  for (int index = hipThreadIdx_x; index < elementSize; index += device::internals::DefaultBlockDim) {
     dstElement[index] += srcElement[index];
   }
 }
@@ -46,7 +46,7 @@ void Algorithms::accumulateBatchedData(real **baseSrcPtr,
                                        unsigned elementSize,
                                        unsigned numElements,
                                        void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid(numElements, 1, 1);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_accumulateBatchedData, grid, block, 0, stream, baseSrcPtr, baseDstPtr, elementSize);
@@ -60,7 +60,7 @@ __global__ void kernel_touchBatchedMemory(real **basePtr,
   real *element = basePtr[hipBlockIdx_x];
   if (element != nullptr) {
 #pragma unroll 4
-    for (int index = hipThreadIdx_x; index < elementSize; index += DefaultBlockDim) {
+    for (int index = hipThreadIdx_x; index < elementSize; index += device::internals::DefaultBlockDim) {
       if (clean) {
         element[index] = 0.0;
       } else {
@@ -79,7 +79,7 @@ void Algorithms::touchBatchedMemory(real **basePtr,
                                     unsigned numElements, 
                                     bool clean,
                                     void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid(numElements, 1, 1);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_touchBatchedMemory, grid, block, 0, stream, basePtr, elementSize, clean);
@@ -92,14 +92,14 @@ __global__  void kernel_setToValue(real** out, real value, size_t elementSize, s
   if (elementId < numElements) {
     real *element = out[elementId];
 #pragma unroll 4
-    for (int index = hipThreadIdx_x; index < elementSize; index += DefaultBlockDim) {
+    for (int index = hipThreadIdx_x; index < elementSize; index += device::internals::DefaultBlockDim) {
       element[index] = value;
     }
   }
 }
 
 void Algorithms::setToValue(real** out, real value, size_t elementSize, size_t numElements, void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid(numElements, 1, 1);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_setToValue,
@@ -121,7 +121,7 @@ __global__ void kernel_copyUniformToScatter(T *src, T **dst, size_t srcOffset, s
   T *srcElement = &src[hipBlockIdx_x * srcOffset];
   T *dstElement = dst[hipBlockIdx_x];
 #pragma unroll 4
-  for (int index = hipThreadIdx_x; index < copySize; index += DefaultBlockDim) {
+  for (int index = hipThreadIdx_x; index < copySize; index += device::internals::DefaultBlockDim) {
     dstElement[index] = srcElement[index];
   }
 }
@@ -133,7 +133,7 @@ void Algorithms::copyUniformToScatter(T *src,
                                       size_t copySize,
                                       size_t numElements,
                                       void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid(numElements, 1, 1);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_copyUniformToScatter, grid, block, 0, stream, src, dst, srcOffset, copySize);
@@ -166,7 +166,7 @@ __global__ void kernel_copyScatterToUniform(T **src, T *dst, size_t dstOffset, s
   T *srcElement = src[hipBlockIdx_x];
   T *dstElement = &dst[hipBlockIdx_x * dstOffset];
 #pragma unroll 4
-  for (int index = hipThreadIdx_x; index < copySize; index += DefaultBlockDim) {
+  for (int index = hipThreadIdx_x; index < copySize; index += device::internals::DefaultBlockDim) {
     dstElement[index] = srcElement[index];
   }
 }
@@ -178,7 +178,7 @@ void Algorithms::copyScatterToUniform(T **src,
                                       size_t copySize,
                                       size_t numElements,
                                       void* streamPtr) {
-  dim3 block(DefaultBlockDim, 1, 1);
+  dim3 block(device::internals::DefaultBlockDim, 1, 1);
   dim3 grid(numElements, 1, 1);
   auto stream = reinterpret_cast<internals::deviceStreamT>(streamPtr);
   hipLaunchKernelGGL(kernel_copyScatterToUniform, grid, block, 0, stream, src, dst, dstOffset, copySize);

--- a/algorithms/sycl/ArrayManip.cpp
+++ b/algorithms/sycl/ArrayManip.cpp
@@ -52,7 +52,7 @@ void Algorithms::touchMemory(real *ptr, size_t size, bool clean, void* streamPtr
         if (clean) {
           ptr[id] = 0;
         } else {
-          real value = ptr[id];
+          real& value = ptr[id];
           // See CUDA for explanation
           value += 1;
           value -= 1;

--- a/algorithms/sycl/ArrayManip.cpp
+++ b/algorithms/sycl/ArrayManip.cpp
@@ -8,7 +8,7 @@ using namespace device::internals;
 
 namespace device {
 template <typename T> void Algorithms::scaleArray(T *devArray, T scalar, const size_t numElements, void* streamPtr) {
-  auto rng = computeExecutionRange1D(DefaultBlockDim, numElements);
+  auto rng = computeExecutionRange1D(device::internals::DefaultBlockDim, numElements);
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
@@ -25,7 +25,7 @@ template void Algorithms::scaleArray(int *devArray, int scalar, const size_t num
 template void Algorithms::scaleArray(char *devArray, char scalar, const size_t numElements, void* streamPtr);
 
 template <typename T> void Algorithms::fillArray(T *devArray, const T scalar, const size_t numElements, void* streamPtr) {
-  auto rng = computeExecutionRange1D(DefaultBlockDim, numElements);
+  auto rng = computeExecutionRange1D(device::internals::DefaultBlockDim, numElements);
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
@@ -43,7 +43,7 @@ template void Algorithms::fillArray(unsigned *devArray, unsigned scalar, const s
 template void Algorithms::fillArray(char *devArray, char scalar, const size_t numElements, void* streamPtr);
 
 void Algorithms::touchMemory(real *ptr, size_t size, bool clean, void* streamPtr) {
-  auto rng = computeExecutionRange1D(DefaultBlockDim, size);
+  auto rng = computeExecutionRange1D(device::internals::DefaultBlockDim, size);
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
@@ -69,7 +69,7 @@ void Algorithms::incrementalAdd(
   size_t numElements,
   void* streamPtr) {
 
-  auto rng = computeExecutionRange1D(DefaultBlockDim, numElements);
+  auto rng = computeExecutionRange1D(device::internals::DefaultBlockDim, numElements);
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {

--- a/algorithms/sycl/ArrayManip.cpp
+++ b/algorithms/sycl/ArrayManip.cpp
@@ -7,9 +7,8 @@
 using namespace device::internals;
 
 namespace device {
-
 template <typename T> void Algorithms::scaleArray(T *devArray, T scalar, const size_t numElements, void* streamPtr) {
-  auto rng = computeExecutionRange1D(64, numElements);
+  auto rng = computeExecutionRange1D(DefaultBlockDim, numElements);
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
@@ -26,7 +25,7 @@ template void Algorithms::scaleArray(int *devArray, int scalar, const size_t num
 template void Algorithms::scaleArray(char *devArray, char scalar, const size_t numElements, void* streamPtr);
 
 template <typename T> void Algorithms::fillArray(T *devArray, const T scalar, const size_t numElements, void* streamPtr) {
-  auto rng = computeExecutionRange1D(64, numElements);
+  auto rng = computeExecutionRange1D(DefaultBlockDim, numElements);
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
@@ -44,7 +43,7 @@ template void Algorithms::fillArray(unsigned *devArray, unsigned scalar, const s
 template void Algorithms::fillArray(char *devArray, char scalar, const size_t numElements, void* streamPtr);
 
 void Algorithms::touchMemory(real *ptr, size_t size, bool clean, void* streamPtr) {
-  auto rng = computeExecutionRange1D(256, size);
+  auto rng = computeExecutionRange1D(DefaultBlockDim, size);
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
@@ -70,7 +69,7 @@ void Algorithms::incrementalAdd(
   size_t numElements,
   void* streamPtr) {
 
-  auto rng = computeExecutionRange1D(256, numElements);
+  auto rng = computeExecutionRange1D(DefaultBlockDim, numElements);
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {

--- a/algorithms/sycl/BatchManip.cpp
+++ b/algorithms/sycl/BatchManip.cpp
@@ -8,14 +8,14 @@ using namespace device::internals;
 
 namespace device {
 void Algorithms::streamBatchedData(real **baseSrcPtr, real **baseDstPtr, unsigned elementSize, unsigned numElements, void* streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
+  auto rng = cl::sycl::nd_range<1>{numElements * device::internals::DefaultBlockDim, device::internals::DefaultBlockDim};
 
 ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
       real *srcElement = baseSrcPtr[item.get_group().get_group_id(0)];
       real *dstElement = baseDstPtr[item.get_group().get_group_id(0)];
 #pragma unroll 4
-      for (int index = item.get_local_id(0); index < elementSize; index += DefaultBlockDim) {
+      for (int index = item.get_local_id(0); index < elementSize; index += device::internals::DefaultBlockDim) {
         dstElement[index] = srcElement[index];
       }
     });
@@ -24,14 +24,14 @@ void Algorithms::streamBatchedData(real **baseSrcPtr, real **baseDstPtr, unsigne
 
 void Algorithms::accumulateBatchedData(real **baseSrcPtr, real **baseDstPtr, unsigned elementSize,
                                        unsigned numElements, void* streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
+  auto rng = cl::sycl::nd_range<1>{numElements * device::internals::DefaultBlockDim, device::internals::DefaultBlockDim};
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
       real *srcElement = baseSrcPtr[item.get_group().get_group_id(0)];
       real *dstElement = baseDstPtr[item.get_group().get_group_id(0)];
 #pragma unroll 4
-      for (int index = item.get_local_id(0); index < elementSize; index += DefaultBlockDim) {
+      for (int index = item.get_local_id(0); index < elementSize; index += device::internals::DefaultBlockDim) {
         dstElement[index] += srcElement[index];
       }
     });
@@ -39,14 +39,14 @@ void Algorithms::accumulateBatchedData(real **baseSrcPtr, real **baseDstPtr, uns
 }
 
 void Algorithms::touchBatchedMemory(real **basePtr, unsigned elementSize, unsigned numElements, bool clean, void* streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
+  auto rng = cl::sycl::nd_range<1>{numElements * device::internals::DefaultBlockDim, device::internals::DefaultBlockDim};
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
       real *element = basePtr[item.get_group().get_group_id(0)];
       if (element != nullptr) {
 #pragma unroll 4
-        for (int index = item.get_local_id(0); index < elementSize; index += DefaultBlockDim) {
+        for (int index = item.get_local_id(0); index < elementSize; index += device::internals::DefaultBlockDim) {
           if (clean) {
             element[index] = 0.0;
           } else {
@@ -67,14 +67,14 @@ void Algorithms::setToValue(real** out,
                             size_t elementSize,
                             size_t numElements,
                             void* streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
+  auto rng = cl::sycl::nd_range<1>{numElements * device::internals::DefaultBlockDim, device::internals::DefaultBlockDim};
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
       const auto elementId = item.get_group().get_group_id(0);
       if (elementId < numElements) {
         real *element = out[elementId];
 #pragma unroll 4
-        for (int i = item.get_local_id(0); i < elementSize; i += DefaultBlockDim) {
+        for (int i = item.get_local_id(0); i < elementSize; i += device::internals::DefaultBlockDim) {
           element[i] = value;
         }
       }
@@ -89,7 +89,7 @@ void Algorithms::copyUniformToScatter(T *src,
                                       size_t copySize,
                                       size_t numElements,
                                       void *streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
+  auto rng = cl::sycl::nd_range<1>{numElements * device::internals::DefaultBlockDim, device::internals::DefaultBlockDim};
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
@@ -97,7 +97,7 @@ void Algorithms::copyUniformToScatter(T *src,
       T *dstElement = dst[item.get_group().get_group_id(0)];
 
 #pragma unroll 4
-      for (int index = item.get_local_id(0); index < copySize; index += DefaultBlockDim) {
+      for (int index = item.get_local_id(0); index < copySize; index += device::internals::DefaultBlockDim) {
         dstElement[index] = srcElement[index];
       }
     });
@@ -132,7 +132,7 @@ void Algorithms::copyScatterToUniform(T **src,
                                       size_t copySize,
                                       size_t numElements,
                                       void *streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
+  auto rng = cl::sycl::nd_range<1>{numElements * device::internals::DefaultBlockDim, device::internals::DefaultBlockDim};
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
@@ -140,7 +140,7 @@ void Algorithms::copyScatterToUniform(T **src,
       T *dstElement = &dst[item.get_group().get_group_id(0) * dstOffset];
   
 #pragma unroll 4
-      for (int index = item.get_local_id(0); index < copySize; index += DefaultBlockDim) {
+      for (int index = item.get_local_id(0); index < copySize; index += device::internals::DefaultBlockDim) {
         dstElement[index] = srcElement[index];
       }
     });

--- a/algorithms/sycl/BatchManip.cpp
+++ b/algorithms/sycl/BatchManip.cpp
@@ -50,7 +50,7 @@ void Algorithms::touchBatchedMemory(real **basePtr, unsigned elementSize, unsign
           if (clean) {
             element[index] = 0.0;
           } else {
-            real value = element[index];
+            real& value = element[index];
             // Do something dummy here. We just need to check the pointers point to valid memory locations.
             // Avoid compiler optimization. Possibly, implement a dummy code with asm.
             value += 1.0;

--- a/algorithms/sycl/BatchManip.cpp
+++ b/algorithms/sycl/BatchManip.cpp
@@ -7,16 +7,15 @@
 using namespace device::internals;
 
 namespace device {
-
 void Algorithms::streamBatchedData(real **baseSrcPtr, real **baseDstPtr, unsigned elementSize, unsigned numElements, void* streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * 32, 32};
+  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
 
 ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
       real *srcElement = baseSrcPtr[item.get_group().get_group_id(0)];
       real *dstElement = baseDstPtr[item.get_group().get_group_id(0)];
-
-      for (int index = item.get_local_id(0); index < elementSize; index += item.get_local_range(0)) {
+#pragma unroll 4
+      for (int index = item.get_local_id(0); index < elementSize; index += DefaultBlockDim) {
         dstElement[index] = srcElement[index];
       }
     });
@@ -25,13 +24,14 @@ void Algorithms::streamBatchedData(real **baseSrcPtr, real **baseDstPtr, unsigne
 
 void Algorithms::accumulateBatchedData(real **baseSrcPtr, real **baseDstPtr, unsigned elementSize,
                                        unsigned numElements, void* streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * 32, 32};
+  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
       real *srcElement = baseSrcPtr[item.get_group().get_group_id(0)];
       real *dstElement = baseDstPtr[item.get_group().get_group_id(0)];
-      for (int index = item.get_local_id(0); index < elementSize; index += item.get_local_range(0)) {
+#pragma unroll 4
+      for (int index = item.get_local_id(0); index < elementSize; index += DefaultBlockDim) {
         dstElement[index] += srcElement[index];
       }
     });
@@ -39,23 +39,24 @@ void Algorithms::accumulateBatchedData(real **baseSrcPtr, real **baseDstPtr, uns
 }
 
 void Algorithms::touchBatchedMemory(real **basePtr, unsigned elementSize, unsigned numElements, bool clean, void* streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * 256, 256};
+  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
       real *element = basePtr[item.get_group().get_group_id(0)];
-      int id = item.get_local_id(0);
-      while (id < elementSize) {
-        if (clean) {
-          element[id] = 0.0;
-        } else {
-          real value = element[id];
-          // Do something dummy here. We just need to check the pointers point to valid memory locations.
-          // Avoid compiler optimization. Possibly, implement a dummy code with asm.
-          value += 1.0;
-          value -= 1.0;
+      if (element != nullptr) {
+#pragma unroll 4
+        for (int index = item.get_local_id(0); index < elementSize; index += DefaultBlockDim) {
+          if (clean) {
+            element[index] = 0.0;
+          } else {
+            real value = element[index];
+            // Do something dummy here. We just need to check the pointers point to valid memory locations.
+            // Avoid compiler optimization. Possibly, implement a dummy code with asm.
+            value += 1.0;
+            value -= 1.0;
+          }
         }
-        id += item.get_local_range(0);
       }
     });
   });
@@ -66,14 +67,14 @@ void Algorithms::setToValue(real** out,
                             size_t elementSize,
                             size_t numElements,
                             void* streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * 256, 256};
+  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
       const auto elementId = item.get_group().get_group_id(0);
-      if (elementId) {
+      if (elementId < numElements) {
         real *element = out[elementId];
-        const auto tid = item.get_local_id(0);
-        for (int i = tid; i < elementSize; i += item.get_local_range(0)) {
+#pragma unroll 4
+        for (int i = item.get_local_id(0); i < elementSize; i += DefaultBlockDim) {
           element[i] = value;
         }
       }
@@ -88,13 +89,15 @@ void Algorithms::copyUniformToScatter(T *src,
                                       size_t copySize,
                                       size_t numElements,
                                       void *streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * 256, 256};
+  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
       T *srcElement = &src[item.get_group().get_group_id(0) * srcOffset];
       T *dstElement = dst[item.get_group().get_group_id(0)];
-      for (int index = item.get_local_id(0); index < copySize; index += item.get_local_range(0)) {
+
+#pragma unroll 4
+      for (int index = item.get_local_id(0); index < copySize; index += DefaultBlockDim) {
         dstElement[index] = srcElement[index];
       }
     });
@@ -129,13 +132,15 @@ void Algorithms::copyScatterToUniform(T **src,
                                       size_t copySize,
                                       size_t numElements,
                                       void *streamPtr) {
-  auto rng = cl::sycl::nd_range<1>{numElements * 256, 256};
+  auto rng = cl::sycl::nd_range<1>{numElements * DefaultBlockDim, DefaultBlockDim};
 
   ((cl::sycl::queue *) streamPtr)->submit([&](cl::sycl::handler &cgh) {
     cgh.parallel_for(rng, [=](cl::sycl::nd_item<> item) {
       T *srcElement = src[item.get_group().get_group_id(0)];
       T *dstElement = &dst[item.get_group().get_group_id(0) * dstOffset];
-      for (int index = item.get_local_id(0); index < copySize; index += item.get_local_range(0)) {
+  
+#pragma unroll 4
+      for (int index = item.get_local_id(0); index < copySize; index += DefaultBlockDim) {
         dstElement[index] = srcElement[index];
       }
     });

--- a/cuda.cmake
+++ b/cuda.cmake
@@ -47,7 +47,3 @@ endif()
 
 find_package(CUDAToolkit REQUIRED)
 target_link_libraries(device PUBLIC CUDA::cudart CUDA::cuda_driver CUDA::nvToolsExt)
-if (ENABLE_PROFILING_MARKERS)
-  target_compile_definitions(device PRIVATE PROFILING_ENABLED)
-endif()
-

--- a/hip.cmake
+++ b/hip.cmake
@@ -70,10 +70,3 @@ if (IS_NVCC_PLATFORM)
 else()
     target_link_libraries(device PUBLIC ${HIP_PATH}/lib/libamdhip64.so)
 endif()
-
-if (USE_GRAPH_CAPTURING)
-    target_compile_definitions(device PRIVATE DEVICE_USE_GRAPH_CAPTURING)
-endif()
-
-target_compile_options(device PRIVATE "-std=c++11")
-

--- a/interfaces/cuda/Control.cu
+++ b/interfaces/cuda/Control.cu
@@ -232,6 +232,18 @@ std::string ConcreteAPI::getDeviceInfoAsText(int deviceId) {
   return info.str();
 }
 
+std::string ConcreteAPI::getApiName() {
+  return "CUDA";
+}
+
+std::string ConcreteAPI::getDeviceName(int deviceId) {
+  cudaDeviceProp property;
+  cudaGetDeviceProperties(&property, deviceId);
+  CHECK_ERR;
+
+  return property.name;
+}
+
 void ConcreteAPI::putProfilingMark(const std::string &name, ProfilingColors color) {
 #ifdef PROFILING_ENABLED
   isFlagSet<DeviceSelected>(status);

--- a/interfaces/cuda/CudaWrappedAPI.h
+++ b/interfaces/cuda/CudaWrappedAPI.h
@@ -39,6 +39,9 @@ public:
   void popStackMemory() override;
   std::string getMemLeaksReport() override;
 
+  std::string getApiName() override;
+  std::string getDeviceName(int deviceId) override;
+
   void copyTo(void *dst, const void *src, size_t count) override;
   void copyFrom(void *dst, const void *src, size_t count) override;
   void copyBetween(void *dst, const void *src, size_t count) override;

--- a/interfaces/cuda/Internals.h
+++ b/interfaces/cuda/Internals.h
@@ -8,6 +8,8 @@ namespace device {
 namespace internals {
 using deviceStreamT = cudaStream_t;
 
+constexpr static int DefaultBlockDim = 256;
+
 void checkErr(const std::string &file, int line);
 inline dim3 computeGrid1D(const dim3 &block, const size_t size) {
   int numBlocks = (size + block.x - 1) / block.x;

--- a/interfaces/hip/Control.cpp
+++ b/interfaces/hip/Control.cpp
@@ -229,6 +229,18 @@ std::string ConcreteAPI::getDeviceInfoAsText(int deviceId) {
   return info.str();
 }
 
+std::string ConcreteAPI::getApiName() {
+  return "HIP";
+}
+
+std::string ConcreteAPI::getDeviceName(int deviceId) {
+  hipDeviceProp_t property;
+  hipGetDeviceProperties(&property, deviceId);
+  CHECK_ERR;
+
+  return property.name;
+}
+
 void ConcreteAPI::putProfilingMark(const std::string &name, ProfilingColors color) {
 #ifdef PROFILING_ENABLED
   isFlagSet<DeviceSelected>(status);

--- a/interfaces/hip/HipWrappedAPI.h
+++ b/interfaces/hip/HipWrappedAPI.h
@@ -40,6 +40,9 @@ public:
   void popStackMemory() override;
   std::string getMemLeaksReport() override;
 
+  std::string getApiName() override;
+  std::string getDeviceName(int deviceId) override;
+
   void copyTo(void *dst, const void *src, size_t count) override;
   void copyFrom(void *dst, const void *src, size_t count) override;
   void copyBetween(void *dst, const void *src, size_t count) override;

--- a/interfaces/hip/Internals.h
+++ b/interfaces/hip/Internals.h
@@ -7,6 +7,9 @@
 #define CHECK_ERR device::internals::checkErr(__FILE__,__LINE__)
 namespace device {
   namespace internals {
+
+    constexpr static int DefaultBlockDim = 256;
+    
     using deviceStreamT = hipStream_t;
     void checkErr(const std::string &file, int line);
     inline dim3 computeGrid1D(const dim3 &block, const size_t size) {

--- a/interfaces/sycl/Control.cpp
+++ b/interfaces/sycl/Control.cpp
@@ -161,7 +161,7 @@ std::string ConcreteAPI::getApiName() {
 }
 
 std::string ConcreteAPI::getDeviceName(int deviceId) {
-  auto device = this->availableDevices[id]->queueBuffer.getDefaultQueue().get_device();
+  auto device = this->availableDevices[deviceId]->queueBuffer.getDefaultQueue().get_device();
 
   std::ostringstream info{};
   info << device.get_info<cl::sycl::info::device::name>()

--- a/interfaces/sycl/Control.cpp
+++ b/interfaces/sycl/Control.cpp
@@ -91,6 +91,8 @@ void ConcreteAPI::finalize() {
   this->availableDevices.clear();
   this->availableDevices.shrink_to_fit();
 
+  this->graphs.clear();
+
   this->currentDeviceStack = nullptr;
   this->currentStatistics = nullptr;
   this->currentQueueBuffer = nullptr;
@@ -150,6 +152,19 @@ std::string ConcreteAPI::getDeviceInfoAsText(cl::sycl::device dev) {
   info << "    driver_version: " << dev.get_info<cl::sycl::info::device::driver_version>() << "\n";
   // if (dev.get_info<info::device::device_type>() != cl::sycl::info::device_type::host)
   // info << "    device id: " << dev.get() << "\n";
+
+  return info.str();
+}
+
+std::string ConcreteAPI::getApiName() {
+  return "SYCL";
+}
+
+std::string ConcreteAPI::getDeviceName(int deviceId) {
+  auto device = this->availableDevices[id]->queueBuffer.getDefaultQueue().get_device();
+
+  std::ostringstream info{};
+  info << device.get_info<cl::sycl::info::device::name>() << " (" << convertToString(dev.get_info<cl::sycl::info::device::device_type>()) << ")";
 
   return info.str();
 }

--- a/interfaces/sycl/Control.cpp
+++ b/interfaces/sycl/Control.cpp
@@ -164,7 +164,8 @@ std::string ConcreteAPI::getDeviceName(int deviceId) {
   auto device = this->availableDevices[id]->queueBuffer.getDefaultQueue().get_device();
 
   std::ostringstream info{};
-  info << device.get_info<cl::sycl::info::device::name>() << " (" << convertToString(dev.get_info<cl::sycl::info::device::device_type>()) << ")";
+  info << device.get_info<cl::sycl::info::device::name>()
+        << " (" << convertToString(device.get_info<cl::sycl::info::device::device_type>()) << ")";
 
   return info.str();
 }

--- a/interfaces/sycl/Control.cpp
+++ b/interfaces/sycl/Control.cpp
@@ -169,11 +169,7 @@ std::string ConcreteAPI::getApiName() {
 std::string ConcreteAPI::getDeviceName(int deviceId) {
   auto device = this->availableDevices[deviceId]->queueBuffer.getDefaultQueue().get_device();
 
-  std::ostringstream info{};
-  info << device.get_info<cl::sycl::info::device::name>()
-        << " (" << convertToString(device.get_info<cl::sycl::info::device::device_type>()) << ")";
-
-  return info.str();
+  return device.get_info<cl::sycl::info::device::name>();
 }
 
 void ConcreteAPI::putProfilingMark(const std::string &name, ProfilingColors color) {

--- a/interfaces/sycl/DeviceCircularQueueBuffer.cpp
+++ b/interfaces/sycl/DeviceCircularQueueBuffer.cpp
@@ -3,32 +3,56 @@
 #include "utils/logger.h"
 
 namespace device {
+QueueWrapper::QueueWrapper(const cl::sycl::device& dev, const std::function<void(cl::sycl::exception_list l)>& handler)
+: queue{dev, handler, cl::sycl::property::queue::in_order()} {
+}
+
+void QueueWrapper::synchronize() {
+  queue.wait_and_throw();
+}
+void QueueWrapper::dependency(QueueWrapper& other) {
+  // improvising... Adding an empty event here, mimicking a CUDA-like event dependency
+  auto queueEvent = other.queue.submit([&](sycl::handler& h) {});
+  queue.submit([&](sycl::handler& h) {
+    h.depends_on(queueEvent);
+  });
+}
+
 DeviceCircularQueueBuffer::DeviceCircularQueueBuffer(
     const cl::sycl::device& dev,
     const std::function<void(cl::sycl::exception_list)>& handler,
     size_t capacity)
-    : queues{std::vector<cl::sycl::queue>(capacity)}, deviceReference(dev), handlerReference(handler) {
+    : queues{std::vector<QueueWrapper>(capacity)}, deviceReference(dev), handlerReference(handler) {
   if (capacity <= 0)
     throw std::invalid_argument("Capacity must be at least 1!");
 
-  this->defaultQueue = cl::sycl::queue{dev, handler, cl::sycl::property::queue::in_order()};
-  this->genericQueue = cl::sycl::queue{dev, handler, cl::sycl::property::queue::in_order()};
+  this->defaultQueue = QueueWrapper(dev, handler);
+  this->genericQueue = QueueWrapper(dev, handler);
   for (size_t i = 0; i < capacity; i++) {
-    this->queues[i] = cl::sycl::queue{dev, handler, cl::sycl::property::queue::in_order()};
+    this->queues[i] = QueueWrapper(dev, handler);
   }
 }
 
 cl::sycl::queue& DeviceCircularQueueBuffer::getDefaultQueue() {
-  return defaultQueue;
+  return defaultQueue.queue;
 }
 
 cl::sycl::queue& DeviceCircularQueueBuffer::getGenericQueue() {
-  return genericQueue;
+  return genericQueue.queue;
 }
 
 cl::sycl::queue& DeviceCircularQueueBuffer::getNextQueue() {
   (++this->counter) %= getCapacity();
-  return (this->queues[this->counter]);
+  return (this->queues[this->counter].queue);
+}
+
+std::vector<cl::sycl::queue> DeviceCircularQueueBuffer::allQueues() {
+  std::vector<cl::sycl::queue> queueCopy(queues.size() + 1);
+  queueCopy[0] = defaultQueue.queue;
+  for (size_t i = 0; i < queues.size(); ++i) {
+    queueCopy[i+1] = queues[i].queue;
+  }
+  return queueCopy;
 }
 
 cl::sycl::queue DeviceCircularQueueBuffer::newQueue() {
@@ -43,6 +67,18 @@ size_t DeviceCircularQueueBuffer::getCapacity() {
   return queues.size();
 }
 
+void DeviceCircularQueueBuffer::forkQueueDepencency() {
+  for (auto& queue : this->queues) {
+    queue.dependency(defaultQueue);
+  }
+}
+
+void DeviceCircularQueueBuffer::joinQueueDepencency() {
+  for (auto& queue : this->queues) {
+    defaultQueue.dependency(queue);
+  }
+}
+
 void DeviceCircularQueueBuffer::syncQueueWithHost(cl::sycl::queue *queuePtr) {
   if (!this->exists(queuePtr))
     throw std::invalid_argument("DEVICE::ERROR: passed stream does not belong to circular stream buffer");
@@ -51,19 +87,19 @@ void DeviceCircularQueueBuffer::syncQueueWithHost(cl::sycl::queue *queuePtr) {
 }
 
 void DeviceCircularQueueBuffer::syncAllQueuesWithHost() {
-  defaultQueue.wait_and_throw();
+  defaultQueue.synchronize();
   for (auto &q : this->queues) {
-    q.wait_and_throw();
+    q.synchronize();
   }
 }
 
 bool DeviceCircularQueueBuffer::exists(cl::sycl::queue *queuePtr) {
-  bool isDefaultQueue = queuePtr == (&defaultQueue);
-  bool isGenericQueue = queuePtr == (&genericQueue);
+  bool isDefaultQueue = queuePtr == (&defaultQueue.queue);
+  bool isGenericQueue = queuePtr == (&genericQueue.queue);
 
   bool isReservedQueue{true};
   for (auto& reservedQueue : queues) {
-    if (queuePtr != (&reservedQueue)) {
+    if (queuePtr != (&reservedQueue.queue)) {
       isReservedQueue = false;
       break;
     }

--- a/interfaces/sycl/DeviceCircularQueueBuffer.cpp
+++ b/interfaces/sycl/DeviceCircularQueueBuffer.cpp
@@ -12,8 +12,8 @@ void QueueWrapper::synchronize() {
 }
 void QueueWrapper::dependency(QueueWrapper& other) {
   // improvising... Adding an empty event here, mimicking a CUDA-like event dependency
-  auto queueEvent = other.queue.submit([&](sycl::handler& h) {});
-  queue.submit([&](sycl::handler& h) {
+  auto queueEvent = other.queue.submit([&](cl::sycl::handler& h) {});
+  queue.submit([&](cl::sycl::handler& h) {
     h.depends_on(queueEvent);
   });
 }

--- a/interfaces/sycl/DeviceCircularQueueBuffer.cpp
+++ b/interfaces/sycl/DeviceCircularQueueBuffer.cpp
@@ -4,10 +4,10 @@
 
 namespace device {
 DeviceCircularQueueBuffer::DeviceCircularQueueBuffer(
-    cl::sycl::device dev,
-    std::function<void(cl::sycl::exception_list)> handler,
+    const cl::sycl::device& dev,
+    const std::function<void(cl::sycl::exception_list)>& handler,
     size_t capacity)
-    : queues{std::vector<cl::sycl::queue>(capacity)} {
+    : queues{std::vector<cl::sycl::queue>(capacity)}, deviceReference(dev), handlerReference(handler) {
   if (capacity <= 0)
     throw std::invalid_argument("Capacity must be at least 1!");
 
@@ -29,6 +29,10 @@ cl::sycl::queue& DeviceCircularQueueBuffer::getGenericQueue() {
 cl::sycl::queue& DeviceCircularQueueBuffer::getNextQueue() {
   (++this->counter) %= getCapacity();
   return (this->queues[this->counter]);
+}
+
+cl::sycl::queue DeviceCircularQueueBuffer::newQueue() {
+  return cl::sycl::queue{deviceReference, handlerReference, cl::sycl::property::queue::in_order()};
 }
 
 void DeviceCircularQueueBuffer::resetIndex() {

--- a/interfaces/sycl/DeviceCircularQueueBuffer.h
+++ b/interfaces/sycl/DeviceCircularQueueBuffer.h
@@ -15,8 +15,8 @@ public:
    * Creates a new circular buffer containing sycl queues. The buffer needs
    * an async exception handler and a capacity that is currently per default 8.
    */
-  DeviceCircularQueueBuffer(cl::sycl::device dev,
-                            std::function<void(cl::sycl::exception_list l)> f,
+  DeviceCircularQueueBuffer(const cl::sycl::device& dev,
+                            const std::function<void(cl::sycl::exception_list l)>& f,
                             size_t capacity = 6);
 
   /*
@@ -35,6 +35,8 @@ public:
    * Returns the next queue within the capacity of this buffer.
    */
   cl::sycl::queue &getNextQueue();
+
+  cl::sycl::queue newQueue();
 
   /*
    * Resets the index to the current element.
@@ -66,6 +68,8 @@ private:
   cl::sycl::queue genericQueue;
   std::vector<cl::sycl::queue> queues;
   size_t counter;
+  const cl::sycl::device& deviceReference;
+  const std::function<void(cl::sycl::exception_list)>& handlerReference;
 };
 
 } // namespace device

--- a/interfaces/sycl/DeviceCircularQueueBuffer.h
+++ b/interfaces/sycl/DeviceCircularQueueBuffer.h
@@ -8,6 +8,15 @@
 
 
 namespace device {
+struct QueueWrapper {
+  cl::sycl::queue queue;
+  QueueWrapper() = default;
+  QueueWrapper(const cl::sycl::device& dev, const std::function<void(cl::sycl::exception_list l)>& f);
+
+  void synchronize();
+  void dependency(QueueWrapper& other);
+};
+
 class DeviceCircularQueueBuffer {
 public:
 
@@ -38,6 +47,8 @@ public:
 
   cl::sycl::queue newQueue();
 
+  std::vector<cl::sycl::queue> allQueues();
+
   /*
    * Resets the index to the current element.
    */
@@ -63,13 +74,17 @@ public:
    */
   bool exists(cl::sycl::queue *queuePtr);
 
+  void forkQueueDepencency();
+
+  void joinQueueDepencency();
+
 private:
-  cl::sycl::queue defaultQueue;
-  cl::sycl::queue genericQueue;
-  std::vector<cl::sycl::queue> queues;
+  QueueWrapper defaultQueue;
+  QueueWrapper genericQueue;
+  std::vector<QueueWrapper> queues;
   size_t counter;
-  const cl::sycl::device& deviceReference;
-  const std::function<void(cl::sycl::exception_list)>& handlerReference;
+  cl::sycl::device deviceReference;
+  std::function<void(cl::sycl::exception_list)> handlerReference;
 };
 
 } // namespace device

--- a/interfaces/sycl/Graphs.cpp
+++ b/interfaces/sycl/Graphs.cpp
@@ -46,20 +46,18 @@ void ConcreteAPI::streamBeginCapture() {
         localQueue.get_context(),
         localQueue.get_device()
       );
-    auto startEvent = cl::sycl::event();
 
     graphs.emplace_back(GraphDetails {
       std::nullopt,
       std::move(recordingGraph),
       std::move(localQueue),
-      std::move(startEvent),
       false
     });
   }
 
   GraphDetails &graphInstance = graphs.back();
 
-  graphInstance.graph.begin_recording(this->currentQueueBuffer->getDefaultQueue());
+  graphInstance.graph.begin_recording(this->currentQueueBuffer->allQueues());
 #endif
 }
 

--- a/interfaces/sycl/Graphs.cpp
+++ b/interfaces/sycl/Graphs.cpp
@@ -1,4 +1,4 @@
-#include "HipWrappedAPI.h"
+#include "SyclWrappedAPI.h"
 #include "Internals.h"
 #include "utils/logger.h"
 #include <cassert>

--- a/interfaces/sycl/Graphs.cpp
+++ b/interfaces/sycl/Graphs.cpp
@@ -1,0 +1,113 @@
+#include "HipWrappedAPI.h"
+#include "Internals.h"
+#include "utils/logger.h"
+#include <cassert>
+
+using namespace device;
+
+/* This is a wrapped graph capturing CUDA mechanism.
+ * Call the following in order to capture a computational graph
+ *    streamBeginCapture();              // 1
+ *
+ *    // your GPU code here              // 2
+ *
+ *    streamEndCapture();                // 3
+ *    auto graph = getGraphInstance();   // 4
+ *
+ * Once you have a compute-graph recorded you can invoke it as follows:
+ *    launchGraph(graph)                 // 1
+ *    syncGraph(graph)                   // 2
+ * */
+
+namespace device {
+namespace graph_capturing {
+
+} // namespace graph_capturing
+} // namespace device
+
+
+bool ConcreteAPI::isCapableOfGraphCapturing() {
+#ifdef DEVICE_USE_GRAPH_CAPTURING_ONEAPI_EXT
+  return true;
+#else
+  return false;
+#endif
+}
+
+
+void ConcreteAPI::streamBeginCapture() {
+#ifdef DEVICE_USE_GRAPH_CAPTURING_ONEAPI_EXT
+  isFlagSet<CircularStreamBufferInitialized>(status);
+  assert(!isCircularStreamsForked && "circular streams must be joined before graph capturing");
+
+  {
+    auto localQueue = availableDevices[currentDeviceId]->newQueue();
+    auto recordingGraph = sycl::ext::oneapi::experimental::command_graph
+      <sycl::ext::oneapi::experimental::graph_state::modifiable>(
+        localQueue.get_context(),
+        localQueue.get_device()
+      );
+    auto startEvent = cl::sycl::event();
+
+    graphs.emplace_back(GraphDetails {
+      std::move(recordingGraph),
+      std::optional::nullopt_t,
+      std::move(localQueue),
+      std::move(startEvent),
+      false
+    });
+  }
+
+  GraphDetails &graphInstance = graphs.back();
+
+  graphInstance.graph.begin_recording(this->currentQueueBuffer->getDefaultQueue());
+#endif
+}
+
+
+void ConcreteAPI::streamEndCapture() {
+#ifdef DEVICE_USE_GRAPH_CAPTURING_ONEAPI_EXT
+  isFlagSet<CircularStreamBufferInitialized>(status);
+  assert(!isCircularStreamsForked && "circular streams must be joined before graph capturing");
+
+  graphInstance.graph.end_recording();
+  graphInstance.instance = std::make_optional<decltype(graphInstance.instance)>(graphInstance.graph.finalize());
+
+  graphInstance.ready = true;
+#endif
+}
+
+
+DeviceGraphHandle ConcreteAPI::getLastGraphHandle() {
+#ifdef DEVICE_USE_GRAPH_CAPTURING_ONEAPI_EXT
+  isFlagSet<CircularStreamBufferInitialized>(status);
+  assert(graphs.back().ready && "a graph has not been fully captured");
+  return DeviceGraphHandle(graphs.size() - 1);
+#else
+  return DeviceGraphHandle();
+#endif
+}
+
+
+void ConcreteAPI::launchGraph(DeviceGraphHandle graphHandle) {
+#ifdef DEVICE_USE_GRAPH_CAPTURING_ONEAPI_EXT
+  isFlagSet<CircularStreamBufferInitialized>(status);
+  assert(graphHandle.isInitialized() && "a graph must be captured before launching");
+  auto &graphInstance = graphs[graphHandle.getGraphId()];
+  graphInstance.queue.submit([&](sycl::handler& handler) {
+    handler.ext_oneapi_graph(graphInstance.instance.value());
+  });
+  CHECK_ERR;
+#endif
+}
+
+
+void ConcreteAPI::syncGraph(DeviceGraphHandle graphHandle) {
+#ifdef DEVICE_USE_GRAPH_CAPTURING_ONEAPI_EXT
+  isFlagSet<CircularStreamBufferInitialized>(status);
+  assert(graphHandle.isInitialized() && "a graph must be captured before synchronizing");
+  auto &graphInstance = graphs[graphHandle.getGraphId()];
+  graphInstance.queue.wait_and_throw();
+  CHECK_ERR;
+#endif
+}

--- a/interfaces/sycl/Internals.h
+++ b/interfaces/sycl/Internals.h
@@ -11,6 +11,8 @@ namespace device {
 namespace internals {
 constexpr int WARP_SIZE = 32;
 
+constexpr static int DefaultBlockDim = 256;
+
 /*
  * Computes the execution range for a 1D range kernel given a target work group size and a total size.
  * The method determines how many work groups are needed to handle the total size given the local execution size

--- a/interfaces/sycl/SyclWrappedAPI.h
+++ b/interfaces/sycl/SyclWrappedAPI.h
@@ -115,7 +115,6 @@ private:
     std::optional<sycl::ext::oneapi::experimental::command_graph<sycl::ext::oneapi::experimental::graph_state::executable>> instance;
     sycl::ext::oneapi::experimental::command_graph<sycl::ext::oneapi::experimental::graph_state::modifiable> graph;
     cl::sycl::queue queue;
-    cl::sycl::event event;
     bool ready{false};
   };
 #else

--- a/interfaces/sycl/SyclWrappedAPI.h
+++ b/interfaces/sycl/SyclWrappedAPI.h
@@ -82,14 +82,12 @@ public:
   void joinCircularStreamsToDefault() override;
   bool isCircularStreamsJoinedWithDefault() override;
 
-  bool isCapableOfGraphCapturing() override { return false; };
-  void streamBeginCapture() override {};
-  void streamEndCapture() override {};
-  DeviceGraphHandle getLastGraphHandle() override {
-      return DeviceGraphHandle{};
-  };
-  void launchGraph(DeviceGraphHandle graphHandle) override {};
-  void syncGraph(DeviceGraphHandle graphHandle) override {};
+  bool isCapableOfGraphCapturing() override;
+  void streamBeginCapture() override;
+  void streamEndCapture() override;
+  DeviceGraphHandle getLastGraphHandle() override;
+  void launchGraph(DeviceGraphHandle graphHandle) override;
+  void syncGraph(DeviceGraphHandle graphHandle) override;
 
   void* createGenericStream() override;
   void destroyGenericStream(void* streamPtr) override;
@@ -114,9 +112,10 @@ private:
 
 #ifdef DEVICE_USE_GRAPH_CAPTURING_ONEAPI_EXT
   struct GraphDetails {
-    std::optional<cl::sycl::ext::oneapi::experimental::command_graph> graph;
-    cl::sycl::ext::oneapi::experimental::command_graph<cl::sycl::ext::oneapi::experimental::graph_state::modifiable> recordingGraph;
+    std::optional<sycl::ext::oneapi::experimental::command_graph<sycl::ext::oneapi::experimental::graph_state::executable>> instance;
+    sycl::ext::oneapi::experimental::command_graph<sycl::ext::oneapi::experimental::graph_state::modifiable> graph;
     cl::sycl::queue queue;
+    cl::sycl::event event;
     bool ready{false};
   };
 #else

--- a/sycl.cmake
+++ b/sycl.cmake
@@ -2,6 +2,7 @@ set(DEVICE_SOURCE_FILES device.cpp
         interfaces/sycl/Aux.cpp
         interfaces/sycl/Control.cpp
         interfaces/sycl/Copy.cpp
+        interfaces/sycl/Graphs.cpp
         interfaces/sycl/Memory.cpp
         interfaces/sycl/Streams.cpp
         interfaces/sycl/DeviceContext.cpp

--- a/sycl.cmake
+++ b/sycl.cmake
@@ -33,6 +33,3 @@ else()
     target_link_libraries(device PRIVATE dpcpp::device_flags)
     target_compile_definitions(device PRIVATE ONEAPI_UNDERHOOD)
 endif()
-
-target_compile_options(device PRIVATE  "-O3")
-target_link_libraries(device PUBLIC stdc++fs)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ add_subdirectory(root)
 
 find_package(GTest REQUIRED)
 
-add_executable(tests main.cpp reductions.cpp array_manip.cpp memory.cpp)
+add_executable(tests main.cpp reductions.cpp array_manip.cpp memory.cpp batch_manip.cpp)
 target_link_libraries(tests PRIVATE device ${GTEST_BOTH_LIBRARIES})
 target_include_directories(tests PRIVATE root ${GTEST_INCLUDE_DIR})
 target_compile_definitions(tests PRIVATE REAL_SIZE=${REAL_SIZE_IN_BYTES})

--- a/tests/batch_manip.cpp
+++ b/tests/batch_manip.cpp
@@ -10,6 +10,7 @@ using namespace ::testing;
 class BatchManip : public BaseTestSuite {
   using BaseTestSuite::BaseTestSuite;
 
+public:
   template<typename T, typename F>
   void testWrapper(size_t N, bool sparse, F&& inner) {
     int *data = (int *)device->api->allocGlobMem(N * sizeof(T));

--- a/tests/batch_manip.cpp
+++ b/tests/batch_manip.cpp
@@ -33,7 +33,7 @@ class BatchManip : public BaseTestSuite {
 
 TEST_F(BatchManip, fill) {
   const int N = 100;
-  testWrapper<int>(N, false, [](int** batch, int* data) {
+  testWrapper<int>(N, false, [&](int** batch, int* data) {
     int scalar = 502;
 
     device->algorithms.fillArray(batch, scalar, N, device->api->getDefaultStream());
@@ -51,7 +51,7 @@ TEST_F(BatchManip, fill) {
 
 TEST_F(BatchManip, touchClean) {
   const int N = 100;
-  testWrapper<real>(N, false, [](real** batch, real* data) {
+  testWrapper<real>(N, false, [&](real** batch, real* data) {
     device->algorithms.touchMemory(batch, N, true, device->api->getDefaultStream());
     std::vector<real> hostVector(N, 1);
 
@@ -64,7 +64,7 @@ TEST_F(BatchManip, touchClean) {
     }
   });
 
-  testWrapper<real>(N, true, [](real** batch, real* data) {
+  testWrapper<real>(N, true, [&](real** batch, real* data) {
     device->algorithms.touchMemory(batch, N, true, device->api->getDefaultStream());
     std::vector<real> hostVector(N, 0);
 
@@ -86,7 +86,7 @@ TEST_F(BatchManip, touchClean) {
 TEST_F(BatchManip, touchNoClean) {
 
   const int N = 100;
-  testWrapper<real>(N, true, [](real** batch, real* data) {
+  testWrapper<real>(N, true, [&](real** batch, real* data) {
     std::vector<real> hostVector(N, 1);
 
     device->api->copyToAsync(arr, &hostVector[0], N * sizeof(real), device->api->getDefaultStream());
@@ -103,7 +103,7 @@ TEST_F(BatchManip, touchNoClean) {
 
 TEST_F(BatchManip, scale) {
   const int N = 100;
-  testWrapper<int>(N, true, [](int** batch, int* data) {
+  testWrapper<int>(N, true, [&](int** batch, int* data) {
     std::vector<int> hostVector(N, 1);
 
     device->api->copyToAsync(data, &hostVector[0], N * sizeof(int), device->api->getDefaultStream());

--- a/tests/batch_manip.cpp
+++ b/tests/batch_manip.cpp
@@ -33,7 +33,7 @@ class BatchManip : public BaseTestSuite {
 
 TEST_F(BatchManip, fill) {
   const int N = 100;
-  testWrapper(N, false, [](int** batch, int* data) {
+  testWrapper<int>(N, false, [](int** batch, int* data) {
     int scalar = 502;
 
     device->algorithms.fillArray(batch, scalar, N, device->api->getDefaultStream());
@@ -51,7 +51,7 @@ TEST_F(BatchManip, fill) {
 
 TEST_F(BatchManip, touchClean) {
   const int N = 100;
-  testWrapper(N, false, [](int** batch, int* data) {
+  testWrapper<real>(N, false, [](real** batch, real* data) {
     device->algorithms.touchMemory(batch, N, true, device->api->getDefaultStream());
     std::vector<real> hostVector(N, 1);
 
@@ -64,7 +64,7 @@ TEST_F(BatchManip, touchClean) {
     }
   });
 
-  testWrapper(N, true, [](int** batch, int* data) {
+  testWrapper<real>(N, true, [](real** batch, real* data) {
     device->algorithms.touchMemory(batch, N, true, device->api->getDefaultStream());
     std::vector<real> hostVector(N, 0);
 
@@ -86,7 +86,7 @@ TEST_F(BatchManip, touchClean) {
 TEST_F(BatchManip, touchNoClean) {
 
   const int N = 100;
-  testWrapper(N, true, [](int** batch, int* data) {
+  testWrapper<real>(N, true, [](real** batch, real* data) {
     std::vector<real> hostVector(N, 1);
 
     device->api->copyToAsync(arr, &hostVector[0], N * sizeof(real), device->api->getDefaultStream());
@@ -103,7 +103,7 @@ TEST_F(BatchManip, touchNoClean) {
 
 TEST_F(BatchManip, scale) {
   const int N = 100;
-  testWrapper(N, true, [](int** batch, int* data) {
+  testWrapper<int>(N, true, [](int** batch, int* data) {
     std::vector<int> hostVector(N, 1);
 
     device->api->copyToAsync(data, &hostVector[0], N * sizeof(int), device->api->getDefaultStream());

--- a/tests/batch_manip.cpp
+++ b/tests/batch_manip.cpp
@@ -35,7 +35,7 @@ public:
 TEST_F(BatchManip, fill) {
   const int N = 100;
   const int M = 120;
-  testWrapper<int>(N, M, false, [&](int** batch, int* data) {
+  testWrapper<real>(N, M, false, [&](real** batch, real* data) {
     int scalar = 502;
 
     device->algorithms.setToValue(batch, scalar, M, N, device->api->getDefaultStream());
@@ -92,9 +92,9 @@ TEST_F(BatchManip, touchNoClean) {
   testWrapper<real>(N, M, false, [&](real** batch, real* data) {
     std::vector<real> hostVector(N * M, 1);
 
-    device->api->copyToAsync(arr, &hostVector[0], N * sizeof(real), device->api->getDefaultStream());
+    device->api->copyToAsync(data, &hostVector[0], N * sizeof(real), device->api->getDefaultStream());
     device->algorithms.touchBatchedMemory(batch, M, N, false, device->api->getDefaultStream());
-    device->api->copyFromAsync(&hostVector[0], arr, N * sizeof(real), device->api->getDefaultStream());
+    device->api->copyFromAsync(&hostVector[0], data, N * sizeof(real), device->api->getDefaultStream());
 
     device->api->syncDefaultStreamWithHost();
 
@@ -108,7 +108,7 @@ TEST_F(BatchManip, scatterToUniform) {
   const int N = 100;
   const int M = 120;
 
-  int *data2 = (real *)device->api->allocMem(N * M * sizeof(T));
+  real *data2 = (real *)device->api->allocGlobMem(N * M * sizeof(T));
   testWrapper<real>(N, M, false, [&](real** batch, real* data) {
     std::vector<int> hostVector(N * M, 1);
 
@@ -129,7 +129,7 @@ TEST_F(BatchManip, scatterToUniform) {
   const int N = 100;
   const int M = 120;
 
-  int *data2 = (real *)device->api->allocMem(N * M * sizeof(T));
+  real *data2 = (real *)device->api->allocGlobMem(N * M * sizeof(T));
   testWrapper<real>(N, M, false, [&](real** batch, real* data) {
     std::vector<int> hostVector(N * M, 1);
 

--- a/tests/batch_manip.cpp
+++ b/tests/batch_manip.cpp
@@ -1,0 +1,119 @@
+#include "BaseTestSuite.h"
+#include "device.h"
+#include "gtest/gtest.h"
+#include <functional>
+#include <vector>
+
+using namespace device;
+using namespace ::testing;
+
+class BatchManip : public BaseTestSuite {
+  using BaseTestSuite::BaseTestSuite;
+
+  template<typename T, typename F>
+  void testWrapper(size_t N, bool sparse, F&& inner) {
+    int *data = (int *)device->api->allocGlobMem(N * sizeof(T));
+    int **batch = (int **)device->api->allocUnifiedMem(N * sizeof(T*));
+
+    for (size_t i = 0; i < N; ++i) {
+      if (!(sparse && i % 2 == 0)) {
+        batch[i] = data + i;
+      }
+      else {
+        batch[i] = nullptr;
+      }
+    }
+
+    std::invoke(std::forward<F>(inner), batch, data);
+
+    device->api->freeMem(data);
+    device->api->freeMem(batch);
+  }
+};
+
+TEST_F(BatchManip, fill) {
+  const int N = 100;
+  testWrapper(N, false, [](int** batch, int* data) {
+    int scalar = 502;
+
+    device->algorithms.fillArray(batch, scalar, N, device->api->getDefaultStream());
+
+    std::vector<int> hostVector(N, 0);
+    device->api->copyFromAsync(&hostVector[0], data, N * sizeof(int), device->api->getDefaultStream());
+
+    device->api->syncDefaultStreamWithHost();
+
+    for (auto &i : hostVector) {
+        EXPECT_EQ(scalar, i);
+    }
+  });
+}
+
+TEST_F(BatchManip, touchClean) {
+  const int N = 100;
+  testWrapper(N, false, [](int** batch, int* data) {
+    device->algorithms.touchMemory(batch, N, true, device->api->getDefaultStream());
+    std::vector<real> hostVector(N, 1);
+
+    device->api->copyFromAsync(&hostVector[0], data, N * sizeof(real), device->api->getDefaultStream());
+
+    device->api->syncDefaultStreamWithHost();
+
+    for (auto &i : hostVector) {
+      EXPECT_EQ(0, i);
+    }
+  });
+
+  testWrapper(N, true, [](int** batch, int* data) {
+    device->algorithms.touchMemory(batch, N, true, device->api->getDefaultStream());
+    std::vector<real> hostVector(N, 0);
+
+    device->api->copyFromAsync(&hostVector[0], data, N * sizeof(real), device->api->getDefaultStream());
+
+    device->api->syncDefaultStreamWithHost();
+
+    for (size_t i = 0; i < hostVector.size(); ++i) {
+      if (i % 2 == 0) {
+        EXPECT_EQ(0, hostVector[i]);
+      }
+      else {
+        EXPECT_EQ(1, hostVector[i]);
+      }
+    }
+  });
+}
+
+TEST_F(BatchManip, touchNoClean) {
+
+  const int N = 100;
+  testWrapper(N, true, [](int** batch, int* data) {
+    std::vector<real> hostVector(N, 1);
+
+    device->api->copyToAsync(arr, &hostVector[0], N * sizeof(real), device->api->getDefaultStream());
+    device->algorithms.touchMemory(batch, N, false, device->api->getDefaultStream());
+    device->api->copyFromAsync(&hostVector[0], arr, N * sizeof(real), device->api->getDefaultStream());
+
+    device->api->syncDefaultStreamWithHost();
+
+    for (auto &i : hostVector) {
+      EXPECT_EQ(0, i);
+    }
+  });
+}
+
+TEST_F(BatchManip, scale) {
+  const int N = 100;
+  testWrapper(N, true, [](int** batch, int* data) {
+    std::vector<int> hostVector(N, 1);
+
+    device->api->copyToAsync(data, &hostVector[0], N * sizeof(int), device->api->getDefaultStream());
+    device->algorithms.scaleArray(batch, 5, N, device->api->getDefaultStream());
+    device->api->copyFromAsync(&hostVector[0], data, N * sizeof(int), device->api->getDefaultStream());
+
+    device->api->syncDefaultStreamWithHost();
+
+    for (auto &i : hostVector) {
+      EXPECT_EQ(5, i);
+    }
+  });
+}

--- a/tests/batch_manip.cpp
+++ b/tests/batch_manip.cpp
@@ -25,7 +25,7 @@ public:
       }
     }
 
-    std::invoke(std::forward<F>(inner), batch, data);
+    std::forward<F>(inner)(batch, data);
 
     device->api->freeMem(data);
     device->api->freeMem(batch);
@@ -125,7 +125,7 @@ TEST_F(BatchManip, scatterToUniform) {
   device->api->freeMem(data2);
 }
 
-TEST_F(BatchManip, scatterToUniform) {
+TEST_F(BatchManip, uniformToScatter) {
   const int N = 100;
   const int M = 120;
 


### PR DESCRIPTION
A few small updates to the device module. Mainly:

* Update the algorithms to use a proper number of threads (and not just a warp/wavefront/subgroup)
* Add tests for batch operations
* Add preliminary support for oneAPI graphs
* Update smaller odds and ends