### PR TITLE
Two Fixes for the HIP Backend

### DIFF
--- a/interfaces/hip/Control.cpp
+++ b/interfaces/hip/Control.cpp
@@ -30,10 +30,11 @@ void ConcreteAPI::setDevice(int deviceId) {
   hipFree(nullptr);
   CHECK_ERR;
 
-  int result;
-  hipDeviceGetAttribute(&result, hipDeviceAttributeDirectManagedMemAccessFromHost, currentDeviceId);
+  int result1, result2;
+  hipDeviceGetAttribute(&result1, hipDeviceAttributeDirectManagedMemAccessFromHost, currentDeviceId);
+  hipDeviceGetAttribute(&result2, hipDeviceAttributePageableMemoryAccessUsesHostPageTables, currentDeviceId);
   CHECK_ERR;
-  usmDefault = result != 0;
+  usmDefault = result1 != 0 && result2 != 0;
 
   status[StatusID::DeviceSelected] = true;
 }

--- a/interfaces/hip/Streams.cpp
+++ b/interfaces/hip/Streams.cpp
@@ -155,7 +155,7 @@ void ConcreteAPI::syncStreamWithEvent(void* streamPtr, void* eventPtr) {
 }
 
 namespace {
-static void streamCallback(hipStream_t, hipError_t, void* data) {
+static void streamCallback(void* data) {
   auto* function = reinterpret_cast<std::function<void()>*>(data);
   (*function)();
   delete function;
@@ -165,6 +165,6 @@ static void streamCallback(hipStream_t, hipError_t, void* data) {
 void ConcreteAPI::streamHostFunction(void* streamPtr, const std::function<void()>& function) {
   hipStream_t stream = static_cast<hipStream_t>(streamPtr);
   auto* functionData = new std::function<void()>(function);
-  hipStreamAddCallback(stream, streamCallback, functionData, 0);
+  hipLaunchHostFunc(stream, streamCallback, functionData);
   CHECK_ERR;
 }


### PR DESCRIPTION
Small two fixes:

* check one more flag when deciding to use managed memory vs. device+host memory
* update the host function to use `hipLaunchHostFunc`