### PR TITLE
Check ROCM_PATH after HIP_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(device_submodule)
 
 #set(CMAKE_CXX_CLANG_TIDY clang-tidy)

--- a/hip.cmake
+++ b/hip.cmake
@@ -2,11 +2,15 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-
-# ensure that we have an set HIP_PATH
+# ensure that we have set HIP_PATH
 if(NOT DEFINED HIP_PATH)
     if(NOT DEFINED ENV{HIP_PATH})
-        set(HIP_PATH "/opt/rocm/hip" CACHE PATH "Path to which HIP has been installed")
+        if (NOT DEFINED ENV{ROCM_PATH})
+            # default location
+            set(HIP_PATH "/opt/rocm" CACHE PATH "Path to which HIP has been installed")
+        else()
+            set(HIP_PATH $ENV{ROCM_PATH} CACHE PATH "Path to which HIP has been installed")
+        endif()
     else()
         set(HIP_PATH $ENV{HIP_PATH} CACHE PATH "Path to which HIP has been installed")
     endif()


### PR DESCRIPTION
Make the ROCm/HIP find by CMake a bit easier.

Most installations only seem to specify `ROCM_PATH`; while we only check `HIP_PATH`. Usually, the problem could be also avoided by setting `HIP_PATH=ROCM_PATH`—so we can also just look to `ROCM_PATH` directly.

Besides, we also increase the required CMake version a bit to evade a warning.
