### PR TITLE
Guard NVTX linking

### DIFF
--- a/cuda.cmake
+++ b/cuda.cmake
@@ -53,5 +53,9 @@ if (EXTRA_DEVICE_FLAGS)
 endif()
 
 find_package(CUDAToolkit REQUIRED)
-target_link_libraries(device PUBLIC CUDA::cudart CUDA::cuda_driver CUDA::nvToolsExt)
+target_link_libraries(device PUBLIC CUDA::cudart CUDA::cuda_driver)
+
+if (ENABLE_PROFILING_MARKERS)
+    target_link_libraries(device PUBLIC CUDA::nvToolsExt)
+endif()
 

--- a/cuda.cmake
+++ b/cuda.cmake
@@ -56,6 +56,6 @@ find_package(CUDAToolkit REQUIRED)
 target_link_libraries(device PUBLIC CUDA::cudart CUDA::cuda_driver)
 
 if (ENABLE_PROFILING_MARKERS)
-    target_link_libraries(device PUBLIC CUDA::nvToolsExt)
+    target_link_libraries(device PUBLIC CUDA::nvtx3)
 endif()
 


### PR DESCRIPTION
(removed in the latest CMake/CUDA versions; plus only needed with enabled profiling markers)
