### PR TITLE
Fix unknown queue error

### DIFF
--- a/interfaces/sycl/DeviceCircularQueueBuffer.cpp
+++ b/interfaces/sycl/DeviceCircularQueueBuffer.cpp
@@ -155,7 +155,15 @@ bool DeviceCircularQueueBuffer::exists(sycl::queue *queuePtr) {
     }
   }
 
-  return isDefaultQueue || isGenericQueue || isReservedQueue;
+  bool isExternalQueue = false;
+  for (auto& queue : externalQueues) {
+    if (queuePtr == queue) {
+      isExternalQueue = true;
+      break;
+    }
+  }
+
+  return isDefaultQueue || isGenericQueue || isReservedQueue || isExternalQueue;
 }
 
 } // namespace device


### PR DESCRIPTION
I dunno what the purpose of "externalQueues" is, but checking queue existence in there fixes the "tried to prefetch usm on a queue that is not known to this device" error. Cf. https://github.com/SeisSol/SeisSol/issues/1442