### PR TITLE
Modified sycl reduction algorithm

### DIFF
--- a/algorithms/sycl/Reduction.cpp
+++ b/algorithms/sycl/Reduction.cpp
@@ -33,7 +33,7 @@ namespace {
   void atomicUpdate(AtomicRef& atomic, AccT value){
 
     constexpr auto MO = sycl::memory_order::relaxed;
-    AccT expected = value;
+    AccT expected = neutral<Type, AccT>();
 
     if constexpr(Type == ReductionType::Add) {
       // Explicity pass MO to fetch_add

--- a/algorithms/sycl/Reduction.cpp
+++ b/algorithms/sycl/Reduction.cpp
@@ -85,7 +85,7 @@ namespace {
           auto reducedValue = sycl::reduce_over_group(idx.get_group(), threadAcc, operation);
 
           if(localId == 0){
-            auto atomic = sycl::atomic_ref<AccT, sycl::memory_order::relaxed,
+            sycl::atomic_ref<AccT, sycl::memory_order::relaxed,
                                       sycl::memory_scope::device,
                                       sycl::access::address_space::global_space> atomicRes(*result);
             atomicUpdate<Type>(atomicRes, reducedValue);

--- a/algorithms/sycl/Reduction.cpp
+++ b/algorithms/sycl/Reduction.cpp
@@ -35,10 +35,26 @@ namespace {
       atomic.fetch_add(value);
     }
     if constexpr(Type == ReductionType::Max) {
-      atomic.fetch_max(value);
+      // sm 60 does not have a fetch max instruction. 
+      // Using our own CAS loop
+      AccT expected = atomic.load();
+      while(value > expected){
+        if(atomic.compare_exchange_weak(expected, value)){
+          break;
+        }
+      }
+      // atomic.fetch_max(value);
     }
     if constexpr(Type == ReductionType::Min) {
-      atomic.fetch_min(value);
+      //sm 60 does not have a fetch min instruction
+      // Using our own CAS loop
+      AccT expected = atomic.load();
+      while(value < expected){
+        if(atomic.compare_exchange_weak(expected, value)){
+          break;
+        }
+      }
+      // atomic.fetch_min(value);
     }
   }
 

--- a/algorithms/sycl/Reduction.cpp
+++ b/algorithms/sycl/Reduction.cpp
@@ -82,10 +82,10 @@ namespace {
 
           idx.barrier(sycl::access::fence_space::local_space);
 
-          auto reducedValue = sycl::educed_over_group(idx.get_group(), threadAcc, operation);
+          auto reducedValue = sycl::reduce_over_group(idx.get_group(), threadAcc, operation);
 
           if(localId == 0){
-            auto atomic = atomic_ref<AccT, sycl::memory_order::relaxed,
+            auto atomic = sycl::atomic_ref<AccT, sycl::memory_order::relaxed,
                                       sycl::memory_scope::device,
                                       sycl::access::address_space::global_space> atomicRes(*result);
             atomicUpdate<Type>(atomicRes, reducedValue);

--- a/algorithms/sycl/Reduction.cpp
+++ b/algorithms/sycl/Reduction.cpp
@@ -101,7 +101,7 @@ namespace {
           for (std::size_t i = 0; i < itemsPerWorkItem*workGroupSize; i += workGroupSize) {
             const auto id = baseIdx + i;
             if(id < size){
-              threadAcc = operation(threadAcc, static_cast<AccT>(ntload(&buffer[id])));
+              threadAcc = operation(threadAcc, static_cast<AccT>((buffer[id])));
             }
           }
 

--- a/algorithms/sycl/Reduction.cpp
+++ b/algorithms/sycl/Reduction.cpp
@@ -101,11 +101,9 @@ namespace {
           for (std::size_t i = 0; i < itemsPerWorkItem*workGroupSize; i += workGroupSize) {
             const auto id = baseIdx + i;
             if(id < size){
-              threadAcc = operation(threadAcc, static_cast<AccT>(&buffer[id]));
+              threadAcc = operation(threadAcc, static_cast<AccT>(ntload(&buffer[id])));
             }
           }
-
-          idx.barrier(sycl::access::fence_space::local_space);
 
           const auto reducedValue = sycl::reduce_over_group(idx.get_group(), threadAcc, operation);
 


### PR DESCRIPTION
Modified sycl reduction algorithm based on @uphoffc's recommendation. Tested the fetch_add implementation and benchmarked it with the current speed on the PVC machine; the average runtime is around 1.5x-4x faster just for sycl reduction on the PVC machines. I did not test it with SeisSol, and as reduction is only a small component of SeisSol, I do not anticipate any significant speed-up in SeisSol runs due to this. 

One problem was the `fetch_max()` and `fetch_min()` methods with sm60, which throw some errors with registers, about which I am not entirely clear. I attempted to implement a manual CAS loop to overcome this. If anyone has ideas on how to surpass this, please let me know. 

The current failed CI test is due to some docker issue, which I am not clear about. 

Can we also add the tests to the CI? There is a folder called `tests` whose tests are not being called in CI as of now, if I understand correctly. 