### PR TITLE
Make the CI actually use some GPUs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,81 +13,94 @@ jobs:
   device-build-test:
     name: device-build-test
     runs-on: ${{ matrix.setup.runner }}
-    container: ${{ matrix.setup.container }}
+    container:
+      image: ${{ matrix.setup.container }}
+      options: ${{ matrix.setup.container-options || ' ' }}
     strategy:
       fail-fast: false
       matrix:
         arch:
-          - snb # <-- needed for the self-hosted CI node for now :/
+          - hsw
         build_type:
           - Release
           - Debug
         setup:
-          - arch: sm_60
+          - arch: sm_86
             backend: cuda
             cc: gcc-13
             cxx: g++-13
             fc: gfortran-13
-            container: seissol/gha-gpu-nv:davschneller-gpu-image
-            runner: ubuntu-24.04
+            container: seissol/gha-gpu-nv:davschneller-ci-merge
+            runner: self-hosted
+            container-options: --runtime=nvidia --gpus=all
             pythonbreak: true
-          - arch: sm_60
+            test: true
+          - arch: sm_86
             backend: acpp
             cc: gcc-13
             cxx: g++-13
             fc: gfortran-13
-            container: seissol/gha-gpu-nv:davschneller-gpu-image
-            runner: ubuntu-24.04
+            container: seissol/gha-gpu-nv:davschneller-ci-merge
+            runner: self-hosted
+            container-options: --runtime=nvidia --gpus=all
             pythonbreak: true
-          - arch: sm_60
+            test: true
+          - arch: sm_86
             backend: cuda
             cc: clang-18
             cxx: clang++-18
             fc: gfortran-13 # TODO?
-            container: seissol/gha-gpu-nv:davschneller-gpu-image
-            runner: ubuntu-24.04
+            container: seissol/gha-gpu-nv:davschneller-ci-merge
+            runner: self-hosted
+            container-options: --runtime=nvidia --gpus=all
             pythonbreak: true
-          # TODO: needs a working GPU runner
-          #- arch: sm_60
-          #  backend: cuda
-          #  cc: nvc
-          #  cxx: nvc++
-          #  fc: nvfortran
-          #  container: seissol/gha-gpu-nvhpc:davschneller-gpu-image
-          #  runner: sccs-ci-nv-sm60
-          #  pythonbreak: true
+            test: true
+          - arch: sm_86
+            backend: cuda
+            cc: nvc
+            cxx: nvc++
+            fc: nvfortran
+            container: seissol/gha-gpu-nvhpc:davschneller-ci-merge
+            runner: self-hosted
+            container-options: --runtime=nvidia --gpus=all
+            pythonbreak: true
+            test: true
           - arch: gfx906
             backend: hip
             cc: gcc-13
             cxx: g++-13
             fc: gfortran-13
-            container: seissol/gha-gpu-amd:davschneller-gpu-image
+            container: seissol/gha-gpu-amd:davschneller-ci-merge
             runner: ubuntu-24.04
             pythonbreak: true
+            test: false
           - arch: gfx906
             backend: acpp
             cc: gcc-13
             cxx: g++-13
             fc: gfortran-13
-            container: seissol/gha-gpu-amd:davschneller-gpu-image
+            container: seissol/gha-gpu-amd:davschneller-ci-merge
             runner: ubuntu-24.04
             pythonbreak: true
+            test: false
           - arch: gfx906
             backend: hip
             cc: clang-18
             cxx: clang++-18
             fc: gfortran-13 # TODO?
-            container: seissol/gha-gpu-amd:davschneller-gpu-image
+            container: seissol/gha-gpu-amd:davschneller-ci-merge
             runner: ubuntu-24.04
             pythonbreak: true
+            test: false
           - arch: skl
             backend: oneapi
             cc: icx
             cxx: icpx
             fc: ifx
-            container: seissol/gha-gpu-intel:davschneller-gpu-image
-            runner: ubuntu-24.04
+            container: seissol/gha-gpu-intel-2025:davschneller-ci-merge
+            runner: self-hosted
             pythonbreak: false
+            test: true
     steps:
       - name: install-gtest
         run: |
@@ -98,7 +111,7 @@ jobs:
           cd ../..
 
       - name: checkout-device
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -121,3 +134,12 @@ jobs:
 
           cmake .. -GNinja -DDEVICE_BACKEND=${{matrix.setup.backend}} -DSM=${{matrix.setup.arch}}
           ninja
+
+      - id: test
+        name: test-device
+        if: ${{matrix.setup.test}}
+        run: |
+          cd tests
+          cd build
+
+          ./tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,8 @@ jobs:
             cc: icx
             cxx: icpx
             fc: ifx
-            container: seissol/gha-gpu-intel-2025:davschneller-ci-merge
+            container: seissol/gha-gpu-intel:davschneller-gpu-image
+            container-options: --device /dev/dri
             runner: self-hosted
             pythonbreak: false
             test: true
@@ -132,7 +133,11 @@ jobs:
           export CXX=${{matrix.setup.cxx}}
           export FC=${{matrix.setup.fc}}
 
-          cmake .. -GNinja -DDEVICE_BACKEND=${{matrix.setup.backend}} -DSM=${{matrix.setup.arch}}
+          cmake .. -GNinja \
+            -DDEVICE_BACKEND=${{matrix.setup.backend}} \
+            -DSM=${{matrix.setup.arch}} \
+            -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+
           ninja
 
       - id: test

--- a/algorithms/cudahip/ArrayManip.cpp
+++ b/algorithms/cudahip/ArrayManip.cpp
@@ -80,7 +80,7 @@ template void
 
 //--------------------------------------------------------------------------------------------------
 __global__ void kernel_touchMemory(void* ptr, size_t size, bool clean) {
-  int id = threadIdx.x + blockIdx.x * blockDim.x;
+  const int id = threadIdx.x + blockIdx.x * blockDim.x;
   if (clean) {
     imemset(ptr, size, id, blockDim.x * gridDim.x);
   } else {

--- a/algorithms/cudahip/BatchManip.cpp
+++ b/algorithms/cudahip/BatchManip.cpp
@@ -132,6 +132,13 @@ template void Algorithms::setToValue(
 template void Algorithms::setToValue(
     unsigned** out, unsigned value, size_t elementSize, size_t numElements, void* streamPtr);
 template void Algorithms::setToValue(
+    long** out, long value, size_t elementSize, size_t numElements, void* streamPtr);
+template void Algorithms::setToValue(unsigned long** out,
+                                     unsigned long value,
+                                     size_t elementSize,
+                                     size_t numElements,
+                                     void* streamPtr);
+template void Algorithms::setToValue(
     char** out, char value, size_t elementSize, size_t numElements, void* streamPtr);
 
 //--------------------------------------------------------------------------------------------------

--- a/algorithms/sycl/BatchManip.cpp
+++ b/algorithms/sycl/BatchManip.cpp
@@ -119,6 +119,13 @@ template void Algorithms::setToValue(
 template void Algorithms::setToValue(
     unsigned** out, unsigned value, size_t elementSize, size_t numElements, void* streamPtr);
 template void Algorithms::setToValue(
+    long** out, long value, size_t elementSize, size_t numElements, void* streamPtr);
+template void Algorithms::setToValue(unsigned long** out,
+                                     unsigned long value,
+                                     size_t elementSize,
+                                     size_t numElements,
+                                     void* streamPtr);
+template void Algorithms::setToValue(
     char** out, char value, size_t elementSize, size_t numElements, void* streamPtr);
 
 void Algorithms::copyUniformToScatterI(const void* src,

--- a/algorithms/sycl/Reduction.cpp
+++ b/algorithms/sycl/Reduction.cpp
@@ -93,8 +93,7 @@ void launchReduction(AccT* result,
         (size + (workGroupSize * itemsPerWorkItem) - 1) / (workGroupSize * itemsPerWorkItem);
 
     cgh.parallel_for(
-        sycl::nd_range<1>{numWorkGroups * itemsPerWorkItem, workGroupSize},
-        [=](sycl::nd_item<1> idx) {
+        sycl::nd_range<1>{numWorkGroups * workGroupSize, workGroupSize}, [=](sycl::nd_item<1> idx) {
           const auto localId = idx.get_local_id(0);
           const auto groupId = idx.get_group(0);
 

--- a/interfaces/sycl/Internals.h
+++ b/interfaces/sycl/Internals.h
@@ -12,7 +12,7 @@
 #include <sycl/sycl.hpp>
 
 namespace device::internals {
-constexpr static int DefaultBlockDim = 1024;
+constexpr static int DefaultBlockDim = 256;
 
 template <typename T>
 void waitCheck(T&& result) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ add_subdirectory(.. root)
 
 find_package(GTest REQUIRED)
 
-add_executable(tests main.cpp reductions.cpp array_manip.cpp memory.cpp batch_manip.cpp)
+add_executable(tests main.cpp reductions.cpp memory.cpp array_manip.cpp batch_manip.cpp)
 target_link_libraries(tests PRIVATE device ${GTEST_BOTH_LIBRARIES})
 target_include_directories(tests PRIVATE ${GTEST_INCLUDE_DIR})
 

--- a/tests/array_manip.cpp
+++ b/tests/array_manip.cpp
@@ -73,15 +73,17 @@ TEST_F(ArrayManip, touchNoClean32) {
   device->api->freeGlobMem(arr);
 }
 
+// avoid double, due to some archs (also in the CI) don't seem to thoroughly support it
+
 TEST_F(ArrayManip, touchClean64) {
 
   const int N = 100;
-  double* arr = (double*)device->api->allocGlobMem(N * sizeof(double));
+  long* arr = (long*)device->api->allocGlobMem(N * sizeof(long));
   device->algorithms.touchMemory(arr, N, true, device->api->getDefaultStream());
-  std::vector<double> hostVector(N, 1);
+  std::vector<long> hostVector(N, 1);
 
   device->api->copyFromAsync(
-      &hostVector[0], arr, N * sizeof(double), device->api->getDefaultStream());
+      &hostVector[0], arr, N * sizeof(long), device->api->getDefaultStream());
 
   device->api->syncDefaultStreamWithHost();
 
@@ -95,14 +97,13 @@ TEST_F(ArrayManip, touchClean64) {
 TEST_F(ArrayManip, touchNoClean64) {
 
   const int N = 100;
-  double* arr = (double*)device->api->allocGlobMem(N * sizeof(double));
-  std::vector<double> hostVector(N, 0);
+  long* arr = (long*)device->api->allocGlobMem(N * sizeof(long));
+  std::vector<long> hostVector(N, 0);
 
-  device->api->copyToAsync(
-      arr, &hostVector[0], N * sizeof(double), device->api->getDefaultStream());
+  device->api->copyToAsync(arr, &hostVector[0], N * sizeof(long), device->api->getDefaultStream());
   device->algorithms.touchMemory(arr, N, false, device->api->getDefaultStream());
   device->api->copyFromAsync(
-      &hostVector[0], arr, N * sizeof(double), device->api->getDefaultStream());
+      &hostVector[0], arr, N * sizeof(long), device->api->getDefaultStream());
 
   device->api->syncDefaultStreamWithHost();
 

--- a/tests/batch_manip.cpp
+++ b/tests/batch_manip.cpp
@@ -32,7 +32,7 @@ class BatchManip : public BaseTestSuite {
     std::forward<F>(inner)(batch, data);
 
     device->api->freeGlobMem(data);
-    device->api->freeGlobMem(batch);
+    device->api->freeUnifiedMem(batch);
   }
 };
 
@@ -166,14 +166,14 @@ TEST_F(BatchManip, uniformToScatter32) {
 TEST_F(BatchManip, fill64) {
   const int N = 100;
   const int M = 120;
-  testWrapper<double>(N, M, false, [&](double** batch, double* data) {
-    double scalar = 502;
+  testWrapper<long>(N, M, false, [&](long** batch, long* data) {
+    long scalar = 502;
 
     device->algorithms.setToValue(batch, scalar, M, N, device->api->getDefaultStream());
 
-    std::vector<double> hostVector(N * M, 0);
+    std::vector<long> hostVector(N * M, 0);
     device->api->copyFromAsync(
-        &hostVector[0], data, N * M * sizeof(double), device->api->getDefaultStream());
+        &hostVector[0], data, N * M * sizeof(long), device->api->getDefaultStream());
 
     device->api->syncDefaultStreamWithHost();
 
@@ -186,12 +186,12 @@ TEST_F(BatchManip, fill64) {
 TEST_F(BatchManip, touchClean64) {
   const int N = 100;
   const int M = 120;
-  testWrapper<double>(N, M, false, [&](double** batch, double* data) {
+  testWrapper<long>(N, M, false, [&](long** batch, long* data) {
     device->algorithms.touchBatchedMemory(batch, M, N, true, device->api->getDefaultStream());
-    std::vector<double> hostVector(N * M, 1);
+    std::vector<long> hostVector(N * M, 1);
 
     device->api->copyFromAsync(
-        &hostVector[0], data, M * N * sizeof(double), device->api->getDefaultStream());
+        &hostVector[0], data, M * N * sizeof(long), device->api->getDefaultStream());
 
     device->api->syncDefaultStreamWithHost();
 
@@ -200,14 +200,14 @@ TEST_F(BatchManip, touchClean64) {
     }
   });
 
-  testWrapper<double>(N, M, true, [&](double** batch, double* data) {
-    std::vector<double> hostVector(N * M, 1);
+  testWrapper<long>(N, M, true, [&](long** batch, long* data) {
+    std::vector<long> hostVector(N * M, 1);
 
     device->api->copyToAsync(
-        data, &hostVector[0], N * M * sizeof(double), device->api->getDefaultStream());
+        data, &hostVector[0], N * M * sizeof(long), device->api->getDefaultStream());
     device->algorithms.touchBatchedMemory(batch, M, N, true, device->api->getDefaultStream());
     device->api->copyFromAsync(
-        &hostVector[0], data, M * N * sizeof(double), device->api->getDefaultStream());
+        &hostVector[0], data, M * N * sizeof(long), device->api->getDefaultStream());
 
     device->api->syncDefaultStreamWithHost();
 
@@ -226,14 +226,14 @@ TEST_F(BatchManip, touchClean64) {
 TEST_F(BatchManip, touchNoClean64) {
   const int N = 100;
   const int M = 120;
-  testWrapper<double>(N, M, false, [&](double** batch, double* data) {
-    std::vector<double> hostVector(N * M, 1);
+  testWrapper<long>(N, M, false, [&](long** batch, long* data) {
+    std::vector<long> hostVector(N * M, 1);
 
     device->api->copyToAsync(
-        data, &hostVector[0], N * M * sizeof(double), device->api->getDefaultStream());
+        data, &hostVector[0], N * M * sizeof(long), device->api->getDefaultStream());
     device->algorithms.touchBatchedMemory(batch, M, N, false, device->api->getDefaultStream());
     device->api->copyFromAsync(
-        &hostVector[0], data, N * M * sizeof(double), device->api->getDefaultStream());
+        &hostVector[0], data, N * M * sizeof(long), device->api->getDefaultStream());
 
     device->api->syncDefaultStreamWithHost();
 
@@ -247,16 +247,16 @@ TEST_F(BatchManip, scatterToUniform64) {
   const int N = 100;
   const int M = 120;
 
-  double* data2 = (double*)device->api->allocGlobMem(N * M * sizeof(double));
-  testWrapper<double>(N, M, false, [&](double** batch, double* data) {
-    std::vector<double> hostVector(N * M, 1);
+  long* data2 = (long*)device->api->allocGlobMem(N * M * sizeof(long));
+  testWrapper<long>(N, M, false, [&](long** batch, long* data) {
+    std::vector<long> hostVector(N * M, 1);
 
     device->api->copyToAsync(
-        data, &hostVector[0], N * M * sizeof(double), device->api->getDefaultStream());
+        data, &hostVector[0], N * M * sizeof(long), device->api->getDefaultStream());
     device->algorithms.copyScatterToUniform(
-        const_cast<const double**>(batch), data2, M, M, N, device->api->getDefaultStream());
+        const_cast<const long**>(batch), data2, M, M, N, device->api->getDefaultStream());
     device->api->copyFromAsync(
-        &hostVector[0], data2, N * M * sizeof(double), device->api->getDefaultStream());
+        &hostVector[0], data2, N * M * sizeof(long), device->api->getDefaultStream());
 
     device->api->syncDefaultStreamWithHost();
 
@@ -271,15 +271,15 @@ TEST_F(BatchManip, uniformToScatter64) {
   const int N = 100;
   const int M = 120;
 
-  double* data2 = (double*)device->api->allocGlobMem(N * M * sizeof(double));
-  testWrapper<double>(N, M, false, [&](double** batch, double* data) {
-    std::vector<double> hostVector(N * M, 1);
+  long* data2 = (long*)device->api->allocGlobMem(N * M * sizeof(long));
+  testWrapper<long>(N, M, false, [&](long** batch, long* data) {
+    std::vector<long> hostVector(N * M, 1);
 
     device->api->copyToAsync(
-        data2, &hostVector[0], N * M * sizeof(double), device->api->getDefaultStream());
+        data2, &hostVector[0], N * M * sizeof(long), device->api->getDefaultStream());
     device->algorithms.copyUniformToScatter(data2, batch, M, M, N, device->api->getDefaultStream());
     device->api->copyFromAsync(
-        &hostVector[0], data, N * M * sizeof(double), device->api->getDefaultStream());
+        &hostVector[0], data, N * M * sizeof(long), device->api->getDefaultStream());
 
     device->api->syncDefaultStreamWithHost();
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -14,5 +14,10 @@ int main(int argc, char** argv) {
   device.api->setDevice(0);
   device.api->initialize();
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+
+  device.api->syncDevice();
+  device.api->finalize();
+
+  return result;
 }


### PR DESCRIPTION
The CI now uses some actual GPUs for testing; for now an NVIDIA dGPU and an Intel iGPU. (i.e. AMD still stays untested here for now—though it should be really similar to the NVIDIA code paths most of the time)

Thus, also switch the CI tests from `double` to `long`; since the currently-used iGPU doesn't support _any_ double it seems.

Currently, we test CUDA, ACPP (both for NVIDIA), and oneAPI (for Intel).

Downside is that it's right now all a self-hosted (i.e. more unstable) runner. I.e. if we take it down or re-setup it, all logs associated with it will be lost.

Also fix a bug in the SYCL reductions (which only became apparent by the CI).
