### PR TITLE
Fix destructor Seg Faults for SYCL

### DIFF
--- a/interfaces/sycl/Memory.cpp
+++ b/interfaces/sycl/Memory.cpp
@@ -51,10 +51,10 @@ void ConcreteAPI::freeMem(void* devPtr) {
   }
 
   // Use the first device context to free memory
-  DeviceContext* context = this->availableDevices[0];
-  if (!context)
+  DeviceContext* context = this->availableDevices[getDeviceId()];
+  if (!context) {
     return;
-
+  }
   auto& map = context->memoryToSizeMap;
 
   if (map.find(devPtr) == map.end()) {

--- a/interfaces/sycl/Memory.cpp
+++ b/interfaces/sycl/Memory.cpp
@@ -38,19 +38,34 @@ void* ConcreteAPI::allocPinnedMem(size_t size, bool compress, Destination hint) 
 void ConcreteAPI::freeMem(void* devPtr) {
   // NOTE: Freeing nullptr results in segfault in oneAPI. It is an opposite behaviour
   // contrast to C++/CUDA/HIP
-  if (devPtr != nullptr && this->currentMemoryToSizeMap != nullptr) {
-    if (this->currentMemoryToSizeMap().find(devPtr) == this->currentMemoryToSizeMap().end()) {
-      throw std::invalid_argument(
-          this->getDeviceInfoAsText(getDeviceId())
-              .append("an attempt to delete memory that has not been allocated. Is this "
-                      "a pointer to this device or was this a double free?"));
-    }
-
-    this->currentStatistics().deallocatedMemBytes += this->currentMemoryToSizeMap().at(devPtr);
-    this->currentMemoryToSizeMap().erase(devPtr);
-    free(devPtr, this->currentDefaultQueue().get_context());
-    waitCheck(currentDefaultQueue());
+  if (devPtr == nullptr) {
+    return;
   }
+
+  if (!this->deviceInitialized) {
+    return;
+  }
+
+  if (this->availableDevices.empty()) {
+    return;
+  }
+
+  // Use the first device context to free memory
+  DeviceContext* context = this->availableDevices[0];
+  if (!context)
+    return;
+
+  auto& map = context->memoryToSizeMap;
+
+  if (map.find(devPtr) == map.end()) {
+    return; // the std::throw is throwing some errors during the program finalization
+  }
+
+  context->statistics.deallocatedMemBytes += map.at(devPtr);
+  map.erase(devPtr);
+  auto& queue = context->queueBuffer.getDefaultQueue();
+  sycl::free(devPtr, queue.get_context());
+  queue.wait();
 }
 
 void ConcreteAPI::freeGlobMem(void* devPtr) {

--- a/interfaces/sycl/Memory.cpp
+++ b/interfaces/sycl/Memory.cpp
@@ -38,7 +38,7 @@ void* ConcreteAPI::allocPinnedMem(size_t size, bool compress, Destination hint) 
 void ConcreteAPI::freeMem(void* devPtr) {
   // NOTE: Freeing nullptr results in segfault in oneAPI. It is an opposite behaviour
   // contrast to C++/CUDA/HIP
-  if (devPtr != nullptr) {
+  if (devPtr != nullptr && this->currentMemoryToSizeMap != nullptr) {
     if (this->currentMemoryToSizeMap().find(devPtr) == this->currentMemoryToSizeMap().end()) {
       throw std::invalid_argument(
           this->getDeviceInfoAsText(getDeviceId())


### PR DESCRIPTION
On SuperMUC Phase 2, there were two double-free or Invalid Pointer Access errors, which caused the program to exit with a Segmentation fault (SIGSEGV). The issue was in `freeMem` method. It was crashing when we tried to destruct the map `this->currentMemoryToSizeMap` if it had already been destructed in another destructor. I modified the checks to return when we encounter empty objects. 