### PR TITLE
Switch to coarse-grained managed HIP allocations by default

### DIFF
--- a/interfaces/hip/Memory.cpp
+++ b/interfaces/hip/Memory.cpp
@@ -26,11 +26,16 @@ void* ConcreteAPI::allocUnifiedMem(size_t size, bool compress, Destination hint)
   isFlagSet<DeviceSelected>(status);
   void* devPtr;
   APIWRAP(hipMallocManaged(&devPtr, size, hipMemAttachGlobal));
+
+  // make coarse-grained memory access behavior the default (match with allocGlobMem)
+  APIWRAP(hipMemAdvise(devPtr, size, hipMemAdviseSetCoarseGrain, 1));
+
   if (hint == Destination::Host) {
     APIWRAP(hipMemAdvise(devPtr, size, hipMemAdviseSetPreferredLocation, hipCpuDeviceId));
   } else {
     APIWRAP(hipMemAdvise(devPtr, size, hipMemAdviseSetPreferredLocation, getDeviceId()));
   }
+
   statistics.allocatedMemBytes += size;
   statistics.allocatedUnifiedMemBytes += size;
   memToSizeMap[devPtr] = size;


### PR DESCRIPTION
Make "unsafe" atomic operations work (as used on gfx90a or some RDNA cards) with managed memory; like they would work with extra "device" memory.
Comes at the downside that the data is only "properly" visible after some synchronization; which should always be ensured in our case right now (i.e. accessing the data only when no kernel is running).
